### PR TITLE
defined missed variable: prediction_expansion_ratio

### DIFF
--- a/src/segger/cli/main.py
+++ b/src/segger/cli/main.py
@@ -121,7 +121,6 @@ def segment(
         group=group_nodes,
     )] = registry.get_default("genes_clusters_resolution"),
 
-
     # Transcript-Transcript Graph
     transcripts_max_k: Annotated[int, registry.get_parameter(
         "transcripts_graph_max_k",  
@@ -144,6 +143,12 @@ def segment(
             group=group_prediction,
         )
     ] = registry.get_default("prediction_graph_mode"),
+
+    prediction_expansion_ratio: Annotated[float, registry.get_parameter(
+        "prediction_graph_buffer_ratio",
+        validator=validators.Number(gt=0),
+        group=group_prediction,
+    )] = registry.get_default("prediction_graph_buffer_ratio"),
 
     prediction_max_k: Annotated[int | None, registry.get_parameter(
         "prediction_graph_max_k",


### PR DESCRIPTION
[Here](https://github.com/dpeerlab/segger/blob/dd681a8c4ed721fd036b3fddd30de89695a848e9/src/segger/cli/main.py#L309), `prediction_expansion_ratio` is passed to the Initializer method of ISTDataModule class while it's not defined beforehand.