### PR TITLE
Create executable module

### DIFF
--- a/src/segger/__main__.py
+++ b/src/segger/__main__.py
@@ -1,0 +1,4 @@
+from segger.cli.main import app
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
Enable calling `segger` using an explicit Python executable, e.g.

```
/path/to/bin/python -m segger --help
```

This is useful for complex or shared environments and allows Segger to be run as an external module without installing every tool into a single virtual environment (helps avoid package version conflicts too)

Implementation is minimal: add `segger/__main__.py`. This is non-breaking.