### PR TITLE
Bugfix/threshold convergence

### DIFF
--- a/src/segger/data/utils/threshold.py
+++ b/src/segger/data/utils/threshold.py
@@ -1,0 +1,12 @@
+from skimage.filters import threshold_li
+
+def threshold_li_custom(arr, max_iter=100):
+    """Fallback to StopIteration if can't converge. Not implemented in threshold_li."""
+    n_iter = 0
+    def _callback(threshold):
+        nonlocal n_iter
+        n_iter += 1
+        if n_iter > max_iter:
+            raise StopIteration
+
+    return threshold_li(arr, iter_callback=_callback)

--- a/src/segger/data/writer.py
+++ b/src/segger/data/writer.py
@@ -178,7 +178,7 @@ class ISTSegmentationWriter(BasePredictionWriter):
                 tli = threshold_li_custom(arr, max_iter=250)
                 threshold = min(tye, tli)
             except StopIteration:
-                logger.debug(f"Failed to converge {feature[0]}. Will use 80% quantile of segger similarities of other genes as cutoff.")
+                logger.debug(f"Failed to converge {feature[0]}. Will use 50% quantile of segger similarities of other genes as cutoff.")
                 failed_to_converge.append(feature[0])
                 continue
 
@@ -190,7 +190,7 @@ class ISTSegmentationWriter(BasePredictionWriter):
             gc.collect()
 
         # backfill failed features in using the 80% quantile of thresholds
-        global_threshold = np.quantile([t["similarity_threshold"] for t in thresholds], .8)
+        global_threshold = np.quantile([t["similarity_threshold"] for t in thresholds], .5)
         for feature in failed_to_converge:
             thresholds.append({tx_fields.feature: feature, "similarity_threshold": global_threshold, "converged": False})
         logger.debug(f"Global Threshold: {global_threshold} | Used this to backfill {len(failed_to_converge)} features.")

--- a/src/segger/data/writer.py
+++ b/src/segger/data/writer.py
@@ -158,8 +158,8 @@ class ISTSegmentationWriter(BasePredictionWriter):
         n = 10_000_000
         thresholds = []
         failed_to_converge = []
-
         n_groups = segmentation_group.len().height
+
         for i, (feature, group) in enumerate(segmentation_group):
 
             # log step
@@ -175,25 +175,25 @@ class ISTSegmentationWriter(BasePredictionWriter):
             # threshold
             try:
                 tye = threshold_yen(arr)
-                tli = threshold_li_custom(arr, max_iter=500)
+                tli = threshold_li_custom(arr, max_iter=250)
                 threshold = min(tye, tli)
             except StopIteration:
-                logger.debug(f"Failed to converge {feature[0]}. Using mean similarity of other genes as cutoff.")
+                logger.debug(f"Failed to converge {feature[0]}. Will use 80% quantile of segger similarities of other genes as cutoff.")
                 failed_to_converge.append(feature[0])
                 continue
 
             # append threshold
-            thresholds.append({tx_fields.feature: feature[0], "similarity_threshold": threshold.item()})
+            thresholds.append({tx_fields.feature: feature[0], "similarity_threshold": threshold.item(), "converged": True})
             
             # cleanup
             del arr
             gc.collect()
 
-        # backfill failed features in using the mean
-        mean_threshold = np.mean([t["similarity_threshold"] for t in thresholds])
+        # backfill failed features in using the 80% quantile of thresholds
+        global_threshold = np.quantile([t["similarity_threshold"] for t in thresholds], .8)
         for feature in failed_to_converge:
-            thresholds.append({tx_fields.feature: feature, "similarity_threshold": mean_threshold})
-        logger.debug(f"Mean Threshold: {mean_threshold} | Used this to backfill {len(failed_to_converge)} features.")
+            thresholds.append({tx_fields.feature: feature, "similarity_threshold": global_threshold, "converged": False})
+        logger.debug(f"Global Threshold: {global_threshold} | Used this to backfill {len(failed_to_converge)} features.")
 
         # Join
         logger.debug("Joining thresholds with segmentation...")

--- a/src/segger/data/writer.py
+++ b/src/segger/data/writer.py
@@ -1,6 +1,9 @@
+import gc
 import logging
+import numpy as np
 from lightning.pytorch.callbacks import BasePredictionWriter
-from skimage.filters import threshold_li, threshold_yen
+from skimage.filters import threshold_yen
+from .utils.threshold import threshold_li_custom
 from lightning.pytorch import Trainer, LightningModule
 from typing import Sequence, Any
 from pathlib import Path
@@ -31,7 +34,7 @@ class ISTSegmentationWriter(BasePredictionWriter):
         if debug:
             logging.getLogger("segger").setLevel("DEBUG")
             self.path_debug = output_directory / "debug"
-            self.path_debug.mkdir(exist_ok=True)
+            self.path_debug.mkdir(exist_ok=True, parents=True)
 
     def write_on_epoch_end(
         self,
@@ -145,41 +148,56 @@ class ISTSegmentationWriter(BasePredictionWriter):
         
         # Per-gene thresholding (iterative to reduce memory usage)
         logger.debug(f"Calculating per-gene similarity thresholds, using {segmentation.shape[0]/1e6:.1f}M transcripts...")
-        feature_counts = (
+        
+        segmentation_group = (
             segmentation
             .filter(pl.col('segger_cell_id').is_not_null())
-            .select(tx_fields.feature)
-            .to_series()
-            .value_counts()
+            .group_by(tx_fields.feature)
         )
-        thresholds = []
+
         n = 10_000_000
-        
-        logger.debug(f"Starting per-gene thresholding for {feature_counts.shape[0]} genes...")
-        for feature, count in feature_counts.iter_rows():
-            similarities = (
-                segmentation
-                .filter(
-                    (pl.col(tx_fields.feature) == feature) &
-                    (pl.col('segger_cell_id').is_not_null())
-                )
-                .select('segger_similarity')
-            )
-            if count > n:
-                similarities = similarities.sample(n=n, seed=0)
-            similarities = similarities.to_series().to_numpy()
-            threshold_value = min(
-                threshold_li( similarities),
-                threshold_yen(similarities),
-            )
-            thresholds.append({
-                tx_fields.feature: feature,
-                'similarity_threshold': threshold_value,
-            })
-        thresholds = pl.DataFrame(thresholds)
-        
+        thresholds = []
+        failed_to_converge = []
+
+        n_groups = segmentation_group.len().height
+        for i, (feature, group) in enumerate(segmentation_group):
+
+            # log step
+            if i % 50 == 0:
+                logger.debug(f"Processing gene {i+1}/{n_groups} (feature {feature[0]} | transcripts {group.shape[0]/1e3:.1f}K)...")
+
+            # sample if too many
+            arr = group["segger_similarity"]
+            if arr.shape[0] > n:
+                arr = arr.sample(n=n, seed=0)
+            arr = arr.to_numpy()
+
+            # threshold
+            try:
+                tye = threshold_yen(arr)
+                tli = threshold_li_custom(arr, max_iter=100)
+                threshold = min(tye, tli)
+            except StopIteration:
+                logger.debug(f"Failed to converge {feature[0]}. Using mean similarity of other genes as cutoff.")
+                failed_to_converge.append(feature[0])
+                continue
+
+            # append threshold
+            thresholds.append({tx_fields.feature: feature[0], "similarity_threshold": threshold.item()})
+            
+            # cleanup
+            del arr
+            gc.collect()
+
+        # backfill failed features in using the mean
+        mean_threshold = np.mean([t["similarity_threshold"] for t in thresholds])
+        for feature in failed_to_converge:
+            thresholds.append({tx_fields.feature: feature, "similarity_threshold": mean_threshold})
+        logger.debug(f"Mean Threshold: {mean_threshold} | Used this to backfill {len(failed_to_converge)} features.")
+
         # Join
         logger.debug("Joining thresholds with segmentation...")
+        thresholds = pl.DataFrame(thresholds)
         segmentation = (
             segmentation
             .join(thresholds, on=tx_fields.feature, how='left')

--- a/src/segger/data/writer.py
+++ b/src/segger/data/writer.py
@@ -1,5 +1,3 @@
-from copyreg import pickle
-import os
 import logging
 from lightning.pytorch.callbacks import BasePredictionWriter
 from skimage.filters import threshold_li, threshold_yen
@@ -8,11 +6,8 @@ from typing import Sequence, Any
 from pathlib import Path
 import polars as pl
 import torch
-
 from ..io import TrainingTranscriptFields, TrainingBoundaryFields
 from . import ISTDataModule
-
-# TODO: import datamodule, not trainer
 
 class ISTSegmentationWriter(BasePredictionWriter):
     """TODO: Description
@@ -32,6 +27,7 @@ class ISTSegmentationWriter(BasePredictionWriter):
         # setup debugging
         self.debug = debug
         self.path_debug = None
+        self.n_tx_predicted = 0
         if debug:
             logging.getLogger("segger").setLevel("DEBUG")
             self.path_debug = output_directory / "debug"
@@ -148,7 +144,7 @@ class ISTSegmentationWriter(BasePredictionWriter):
         )
         
         # Per-gene thresholding (iterative to reduce memory usage)
-        logger.debug("Calculating per-gene similarity thresholds...")
+        logger.debug(f"Calculating per-gene similarity thresholds, using {segmentation.shape[0]/1e6:.1f}M transcripts...")
         feature_counts = (
             segmentation
             .filter(pl.col('segger_cell_id').is_not_null())
@@ -158,6 +154,8 @@ class ISTSegmentationWriter(BasePredictionWriter):
         )
         thresholds = []
         n = 10_000_000
+        
+        logger.debug(f"Starting per-gene thresholding for {feature_counts.shape[0]} genes...")
         for feature, count in feature_counts.iter_rows():
             similarities = (
                 segmentation
@@ -187,17 +185,21 @@ class ISTSegmentationWriter(BasePredictionWriter):
             .join(thresholds, on=tx_fields.feature, how='left')
             .drop(tx_fields.feature)
         )
+
+        logger.debug("Segmentation complete.")
         return segmentation
 
     
     # Debugging callbacks
     def on_predict_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0):
+        mask = batch['tx']['predict_mask']
+        self.n_tx_predicted += mask.sum().item()
         if not self.debug:
             return
         log_every = 50
         if batch_idx % log_every == 0:
             self.segger_logger.info(
-                f"Finished prediction batch '{batch_idx}'."
+                f"Finished prediction batch '{batch_idx}'. # TX so far {self.n_tx_predicted / 1e6:.1f}M"
             )
     
     def on_fit_start(self, trainer, pl_module):

--- a/src/segger/data/writer.py
+++ b/src/segger/data/writer.py
@@ -175,7 +175,7 @@ class ISTSegmentationWriter(BasePredictionWriter):
             # threshold
             try:
                 tye = threshold_yen(arr)
-                tli = threshold_li_custom(arr, max_iter=100)
+                tli = threshold_li_custom(arr, max_iter=500)
                 threshold = min(tye, tli)
             except StopIteration:
                 logger.debug(f"Failed to converge {feature[0]}. Using mean similarity of other genes as cutoff.")

--- a/src/segger/data/writer.py
+++ b/src/segger/data/writer.py
@@ -163,8 +163,8 @@ class ISTSegmentationWriter(BasePredictionWriter):
         for i, (feature, group) in enumerate(segmentation_group):
 
             # log step
-            if i % 50 == 0:
-                logger.debug(f"Processing gene {i+1}/{n_groups} (feature {feature[0]} | transcripts {group.shape[0]/1e3:.1f}K)...")
+            if (i + 1) % 50 == 0:
+                logger.debug(f"Processing feature {i+1}/{n_groups} (feature {feature[0]} | transcripts {group.shape[0]/1e3:.1f}K)...")
 
             # sample if too many
             arr = group["segger_similarity"]

--- a/src/segger/debug/segmentation.py
+++ b/src/segger/debug/segmentation.py
@@ -18,7 +18,7 @@ def run_segmentation_only(
     SLURMEnvironment.detect = lambda: False
 
     # Load data
-    writer = ISTSegmentationWriter(path_outputs)
+    writer = ISTSegmentationWriter(path_outputs, debug=True)
     adata = ad.read_h5ad(path_adata)
     with open(path_predictions, "rb") as f:
         predictions = pickle.load(f)


### PR DESCRIPTION
## Robust Thresholding

The `threshold_li` implementation does not guarantee convergence and has no built-in `max_iter` parameters (like many similar algorithms).

Added a `threshold_li_custom` function which uses a callback to implement `max_iter`. Default to 250.

**Other Implications**

* If a feature fails to converge, it will be backfilled by the 80% percentile of all other thresholds that converged successfully.
* Added `converged` boolean column to `segger_segmentation.parquet` to inform users if thresholding failed.

## Testing

This is tested on a Xenium dataset. Results were compared against a rollback to previous production version. Transcript-To-Cell assignments match 99.2%+. This matches similar results when running previous stable versions repeatedly.