### PR TITLE
[v2-dev] SpatialData loader and writer 

### DIFF
--- a/src/segger/cli/main.py
+++ b/src/segger/cli/main.py
@@ -1484,7 +1484,7 @@ def export(
             print(
                 "Warning: spatialdata not installed. "
                 "Install with: pip install segger[spatialdata]"
-            )
+            )  # triggered whenever the SpatialDataWrite import fails
         return
 
     raise ValueError(f"Unsupported export format: {format}")

--- a/src/segger/data/data_module.py
+++ b/src/segger/data/data_module.py
@@ -39,6 +39,8 @@ from ..io.fields import (
 )
 from .tiling import QuadTreeTiling, SquareTiling
 from .partition import PartitionSampler
+from .utils.anndata import setup_anndata
+from .utils.heterodata import setup_heterodata
 
 
 
@@ -266,8 +268,6 @@ class ISTDataModule(LightningDataModule):
             return
 
         from ..io.preprocessor import get_preprocessor
-        from .utils.anndata import setup_anndata
-        from .utils.heterodata import setup_heterodata
 
         # Load standardized IST data with quality filtering
         pp = get_preprocessor(
@@ -376,32 +376,13 @@ class ISTDataModule(LightningDataModule):
         ImportError
             If spatialdata is not installed.
         """
-        from ..io.spatialdata_loader import SpatialDataLoader, load_from_spatialdata
-        from ..io.quality_filter import get_quality_filter
+        from ..io.spatialdata_loader import SpatialDataLoader
+        from ..io.quality_filter import SpatialDataQualityFilter
 
         tx_fields = StandardTranscriptFields()
         bd_fields = StandardBoundaryFields()
 
-        # Load from SpatialData
-        loader = SpatialDataLoader(path)
-        transcripts_lf = loader.transcripts(normalize=True)
-        boundaries = loader.boundaries(boundary_type="all")
-
-        # Apply quality filtering if needed
-        if self.min_qv is not None and loader.platform:
-            qf = get_quality_filter(loader.platform)
-            transcripts_lf = qf.filter(
-                transcripts_lf,
-                min_threshold=self.min_qv,
-                feature_column=tx_fields.feature,
-            )
-
-        # Collect to DataFrame
-        tx = self.tx = transcripts_lf.collect()
-        bd = self.bd = boundaries
-
-        # Continue with standard processing
-        # Mask transcripts to reference segmentation
+        # Set compartments and boundary type according to segmentation mode
         if self.segmentation_graph_mode == "nucleus":
             compartments = [tx_fields.nucleus_value]
             boundary_type = bd_fields.nucleus_value
@@ -417,13 +398,31 @@ class ISTDataModule(LightningDataModule):
                 f"'{self.segmentation_graph_mode}'."
             )
 
-        # Check if compartment column exists
+        # Load from SpatialData
+        loader = SpatialDataLoader(path)
+        transcripts_lf = loader.transcripts(normalize=True, platform=loader.platform)
+        boundaries = loader.boundaries(boundary_type=boundary_type)
+
+       # Apply quality filtering
+        qf = SpatialDataQualityFilter(loader.platform)
+        transcripts_lf = qf.filter(
+            transcripts_lf,
+            min_threshold=self.min_qv,
+            feature_column=tx_fields.feature,
+        )
+
+        # Collect to DataFrame
+        tx = self.tx = transcripts_lf.collect()
+        bd = self.bd = boundaries
+
+        # Mask trasncripts on the compartment
         if tx_fields.compartment in tx.columns:
             tx_mask = pl.col(tx_fields.compartment).is_in(compartments)
         else:
             # If no compartment info, use cell_id presence
             tx_mask = pl.col(tx_fields.cell_id).is_not_null()
 
+        # Mask boundaries on type
         if bd is not None and bd_fields.boundary_type in bd.columns:
             bd_mask = bd[bd_fields.boundary_type] == boundary_type
         else:

--- a/src/segger/data/tile_dataset.py
+++ b/src/segger/data/tile_dataset.py
@@ -303,6 +303,10 @@ class DynamicBatchSamplerPatch(DynamicBatchSampler):
                 f"'{self.__class__.__name__}' expected {self.mode} <= "
                 f"{self.max_num}, but found {num}. Increase 'max_num' or set "
                 f"'skip_too_big=True'"
+                # for final user the message should be something like:
+                # "Graph is too large for current batch size: increase '--max-nodes-per-batch"  or 
+                #  decrease '--max-nodes-per-tile' and adjust
+                #  '--tiling-margin-training', '--tiling-margin-prediction' accordingly."
             )
         return num
 

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -33,7 +33,7 @@ def anndata_from_transcripts(
     """TODO: Add description.
     """
     _lazy_imports()
-    # Remove non-nuclear transcript
+    # Remove transcripts without cell assignment
     tx = tx.filter(pl.col(cell_id_column).is_not_null())
     # Get sparse counts from transcripts
     if feature_vocab is None:

--- a/src/segger/data/utils/heterodata.py
+++ b/src/segger/data/utils/heterodata.py
@@ -161,6 +161,11 @@ def setup_heterodata(
         tx_fields.cell_cluster,
         tx_fields.gene_cluster,
     ]
+    
+    # Convert feature_name to string for joining
+    if transcripts[tx_fields.feature].dtype != pl.Utf8:
+        transcripts = transcripts.with_columns(pl.col(tx_fields.feature).cast(pl.Utf8))
+    
     # Update transcripts with fields for training
     
     transcripts = (

--- a/src/segger/export/anndata_writer.py
+++ b/src/segger/export/anndata_writer.py
@@ -192,7 +192,7 @@ class AnnDataWriter:
         x_column: Optional[str] = "x",
         y_column: Optional[str] = "y",
         z_column: Optional[str] = "z",
-        overwrite: bool = False,
+        overwrite: bool = None,
         **kwargs,
     ) -> Path:
         """Write segmentation results to AnnData (.h5ad).
@@ -214,6 +214,9 @@ class AnnDataWriter:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         output_path = output_dir / output_name
+
+        # If overwrite is not passed explicitly, set based on path existence
+        overwrite = output_path.exists() if overwrite is None else overwrite
 
         if output_path.exists() and not overwrite:
             raise FileExistsError(

--- a/src/segger/export/spatialdata_writer.py
+++ b/src/segger/export/spatialdata_writer.py
@@ -112,7 +112,7 @@ class SpatialDataWriter:
         x_column: str = "x",
         y_column: str = "y",
         z_column: Optional[str] = "z",
-        overwrite: bool = True,
+        overwrite: bool = None,
         **kwargs,
     ) -> Path:
         """Write segmentation results to SpatialData Zarr store.
@@ -170,6 +170,9 @@ class SpatialDataWriter:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         output_path = output_dir / output_name
+
+        # If overwrite is not passed explicitly, set based on path existence
+        overwrite = output_path.exists() if overwrite is None else overwrite
 
         # Check if exists
         if output_path.exists() and not overwrite:

--- a/src/segger/export/spatialdata_writer.py
+++ b/src/segger/export/spatialdata_writer.py
@@ -112,7 +112,7 @@ class SpatialDataWriter:
         x_column: str = "x",
         y_column: str = "y",
         z_column: Optional[str] = "z",
-        overwrite: bool = False,
+        overwrite: bool = True,
         **kwargs,
     ) -> Path:
         """Write segmentation results to SpatialData Zarr store.
@@ -294,7 +294,7 @@ class SpatialDataWriter:
                 **({"z": z_column} if has_z else {}),
             },
         )
-        elements[f"points/{self.points_key}"] = points
+        elements[self.points_key] = points
 
         # Shapes element (if boundaries provided or generated)
         if self.include_boundaries and self.boundary_method != "skip":
@@ -307,14 +307,14 @@ class SpatialDataWriter:
             )
             if shapes is not None and len(shapes) > 0:
                 shapes_parsed = ShapesModel.parse(shapes)
-                elements[f"shapes/{self.shapes_key}"] = shapes_parsed
+                elements[self.shapes_key] = shapes_parsed
 
         # Create SpatialData
-        sdata = spatialdata.SpatialData.from_elements_dict(elements)
+        sdata = spatialdata.SpatialData.init_from_elements(elements)
 
         # Optional AnnData table
         if self.include_table:
-            region = self.shapes_key if f"shapes/{self.shapes_key}" in elements else None
+            region = self.shapes_key if self.shapes_key in elements else None
             region_key = self.table_region_key if region is not None else None
             table = build_anndata_table(
                 transcripts=transcripts,

--- a/src/segger/export/spatialdata_writer.py
+++ b/src/segger/export/spatialdata_writer.py
@@ -256,7 +256,7 @@ class SpatialDataWriter:
     ) -> "SpatialData":
         """Create SpatialData object from transcripts and boundaries."""
         import spatialdata
-        from spatialdata.models import PointsModel, ShapesModel
+        from spatialdata.models import PointsModel, ShapesModel, TableModel
         import geopandas as gpd
         import pandas as pd
         import dask.dataframe as dd
@@ -319,7 +319,8 @@ class SpatialDataWriter:
         if self.include_table:
             region = self.shapes_key if self.shapes_key in elements else None
             region_key = self.table_region_key if region is not None else None
-            table = build_anndata_table(
+            instance_key = cell_id_column
+            table_data = build_anndata_table(
                 transcripts=transcripts,
                 cell_id_column=cell_id_column,
                 feature_column=feature_column,
@@ -330,6 +331,7 @@ class SpatialDataWriter:
                 region=region,
                 region_key=region_key,
             )
+            table = TableModel.parse(table_data, region, region_key, instance_key, overwrite_metadata=True)
             sdata.tables[self.table_key] = table
 
         return sdata

--- a/src/segger/io/fields.py
+++ b/src/segger/io/fields.py
@@ -23,7 +23,7 @@ class XeniumTranscriptFields:
     z: str = 'z_location'  # Z-coordinate (microns)
     feature: str = 'feature_name'
     cell_id: str = 'cell_id'
-    null_cell_id: str = 'UNASSIGNED'
+    null_cell_id: tuple = ('-1', 'UNASSIGNED')
     compartment: str = 'overlaps_nucleus'
     nucleus_value: int = 1
     quality: str = 'qv'  # Phred-scaled quality value (0-40)

--- a/src/segger/io/fields.py
+++ b/src/segger/io/fields.py
@@ -35,6 +35,7 @@ class XeniumTranscriptFields:
         'DeprecatedCodeword_*',
         'UnassignedCodeword_*',
     ])
+    is_gene: str = 'is_gene'  # filter field in newer Xenium outputs
 
 @dataclass
 class XeniumBoundaryFields:

--- a/src/segger/io/preprocessor.py
+++ b/src/segger/io/preprocessor.py
@@ -469,6 +469,12 @@ class XeniumPreprocessor(ISTPreprocessor):
             .with_row_index(name=std.row_index)
         )
 
+        # Force UTF8 if parquet stored it as Binary (Xenium 1.0.0)
+        if lf.collect_schema()[raw.feature] == pl.Binary:
+            lf = lf.with_columns(
+                pl.col(raw.feature).cast(pl.String)
+            )
+
         # Apply quality filtering using quality_filter module
         qf = XeniumQualityFilter()
         lf = qf.filter(
@@ -480,12 +486,11 @@ class XeniumPreprocessor(ISTPreprocessor):
 
         # Standardize compartment labels
         lf = lf.with_columns(
-            pl.when(pl.col(raw.compartment) == raw.nucleus_value)
+            pl.when(pl.col(raw.compartment) ==  pl.lit(raw.nucleus_value, dtype=pl.UInt8))
             .then(std.nucleus_value)
             .when(
-                (pl.col(raw.compartment) != raw.nucleus_value) &
-                (pl.col(raw.cell_id) != raw.null_cell_id)
-            )
+                (pl.col(raw.compartment) !=  pl.lit(raw.nucleus_value, dtype=pl.UInt8)) &
+                ~pl.col(raw.cell_id).cast(pl.Utf8).is_in(raw.null_cell_id)            )
             .then(std.cytoplasmic_value)
             .otherwise(std.extracellular_value)
             .alias(std.compartment)
@@ -494,6 +499,7 @@ class XeniumPreprocessor(ISTPreprocessor):
         # Standardize cell IDs
         lf = lf.with_columns(
             pl.col(raw.cell_id)
+            .cast(pl.Utf8)
             .replace(raw.null_cell_id, None)
             .alias(std.cell_id)
         )
@@ -574,10 +580,13 @@ class XeniumPreprocessor(ISTPreprocessor):
             nuclei.reset_index(drop=False, names=std.id),
         ])
         # Convert index to string type (to join on AnnData)
-        bd.index = bd[std.id] + '_' + bd[std.boundary_type].map({
+        bd.index = bd[std.id].astype(str) + '_' + bd[std.boundary_type].map({
             std.nucleus_value: '0',
             std.cell_value: '1',
         })
+        # Convert std.id to string type (to join on AnnData)
+        if bd[std.id].dtype != "object":
+            bd[std.id] = bd[std.id].astype(str)
 
         return bd
 

--- a/src/segger/io/quality_filter.py
+++ b/src/segger/io/quality_filter.py
@@ -206,7 +206,10 @@ class XeniumQualityFilter(BaseQualityFilter):
         qv_col = quality_column or self.quality_column
 
         # Filter control probes
-        df = self._filter_by_patterns(df, feature_column)
+        if 'is_gene' in df.collect_schema():
+            df = df.filter(pl.col('is_gene'))  # use ad-hoc column (more robust)
+        else:
+            df = self._filter_by_patterns(df, feature_column)  # fallback to filter by patterns
 
         # Apply QV threshold
         if min_threshold is not None and min_threshold > 0:

--- a/src/segger/io/spatialdata_loader.py
+++ b/src/segger/io/spatialdata_loader.py
@@ -39,7 +39,7 @@ from segger.utils.optional_deps import (
     require_spatialdata,
     warn_spatialdata_io_unavailable,
 )
-from segger.io.fields import StandardTranscriptFields, StandardBoundaryFields
+from segger.io.fields import StandardTranscriptFields, StandardBoundaryFields, XeniumTranscriptFields, XeniumBoundaryFields
 
 if TYPE_CHECKING:
     from spatialdata import SpatialData
@@ -258,6 +258,7 @@ class SpatialDataLoader:
         gene_column: Optional[str] = None,
         quality_column: Optional[str] = None,
         normalize: bool = True,
+        platform: str = None,
     ) -> pl.LazyFrame:
         """Extract transcripts as a normalized Polars LazyFrame.
 
@@ -269,6 +270,8 @@ class SpatialDataLoader:
             Column name for quality scores. Auto-detected if None.
         normalize
             If True, rename columns to standard field names.
+        platfrom
+            Platform to perform complete preprocessing as in preprocessor.py
 
         Returns
         -------
@@ -279,6 +282,10 @@ class SpatialDataLoader:
             - feature_name: Gene symbol
             - qv (optional): Quality score
             - cell_id (optional): Assigned cell
+
+        NOTE: Differently from XeniumPreprocessor.transcripts(), this method does not implement 
+        qv filtering because the parameter 'min_qv' is not visible. 
+        Qv filtering is implemented directly in ISTDataModule._load_from_spatialdata().
         """
         # Get points DataFrame from SpatialData
         points = self.sdata.points[self.points_key]
@@ -328,6 +335,24 @@ class SpatialDataLoader:
         # Build lazy frame with row index
         lf = df.lazy().with_row_index(name=std.row_index)
 
+        # If SD object comes from Xenium
+        if platform == 'xenium':
+            # Load technology-specific fields
+            raw = XeniumTranscriptFields()
+
+            # Standardize compartment labels
+            lf = lf.with_columns(
+                pl.when(pl.col(raw.compartment) ==  pl.lit(raw.nucleus_value, dtype=pl.UInt8))
+                .then(std.nucleus_value)
+                .when(
+                    (pl.col(raw.compartment) !=  pl.lit(raw.nucleus_value, dtype=pl.UInt8)) &
+                    (pl.col(raw.cell_id).cast(pl.Utf8) != raw.null_cell_id)
+                )
+                .then(std.cytoplasmic_value)
+                .otherwise(std.extracellular_value)
+                .alias(std.compartment)
+            )
+
         if normalize:
             # Build rename mapping
             rename_map = {
@@ -358,11 +383,31 @@ class SpatialDataLoader:
                 select_cols.append(std.quality)
             if cell_id_col:
                 select_cols.append(std.cell_id)
+            # Xenium columns
+            if platform == 'xenium':
+                select_cols.append(std.compartment)  # integrated only in Xenium
+                select_cols.append(raw.is_gene)  # for filtering
 
             # Only select columns that exist after renaming
             schema = lf.collect_schema()
             select_cols = [c for c in select_cols if c in schema.names()]
             lf = lf.select(select_cols)
+            # Turn categorical columns into strings
+            lf = lf.with_columns(
+                [
+                    pl.col(c).cast(pl.String) if lf.schema[c] == pl.Categorical
+                    else pl.col(c)
+                    for c in select_cols
+                ]
+            )
+
+            # Standardize cell IDs (this allows the filtering in setup_anndata() to catch 'UNASSIGNED' properly
+            lf = lf.with_columns(
+                pl.col(raw.cell_id)
+                .cast(pl.Utf8)
+                .replace(raw.null_cell_id, None)
+                .alias(std.cell_id)
+            )
 
         return lf
 
@@ -425,7 +470,7 @@ class SpatialDataLoader:
             if std.id not in gdf.columns:
                 if "index" in gdf.columns:
                     gdf[std.id] = gdf["index"]
-                elif gdf.index.name:
+                elif gdf.index.name or gdf.index.all():
                     gdf[std.id] = gdf.index
                 else:
                     gdf[std.id] = range(len(gdf))

--- a/src/segger/io/spatialdata_loader.py
+++ b/src/segger/io/spatialdata_loader.py
@@ -39,7 +39,7 @@ from segger.utils.optional_deps import (
     require_spatialdata,
     warn_spatialdata_io_unavailable,
 )
-from segger.io.fields import StandardTranscriptFields, StandardBoundaryFields, XeniumTranscriptFields, XeniumBoundaryFields
+from segger.io.fields import StandardTranscriptFields, StandardBoundaryFields, XeniumTranscriptFields, CosMxTranscriptFields
 
 if TYPE_CHECKING:
     from spatialdata import SpatialData
@@ -346,11 +346,48 @@ class SpatialDataLoader:
                 .then(std.nucleus_value)
                 .when(
                     (pl.col(raw.compartment) !=  pl.lit(raw.nucleus_value, dtype=pl.UInt8)) &
-                    (pl.col(raw.cell_id).cast(pl.Utf8) != raw.null_cell_id)
+                    (pl.col(raw.cell_id).cast(pl.Utf8).is_in(raw.null_cell_id))
                 )
                 .then(std.cytoplasmic_value)
                 .otherwise(std.extracellular_value)
                 .alias(std.compartment)
+            )
+
+            # Standardize cell IDs
+            lf = lf.with_columns(
+                pl.col(raw.cell_id)
+                .cast(pl.Utf8)
+                .replace({v: None for v in raw.null_cell_id})
+                .alias(std.cell_id)
+            )
+
+        # If SD object comes from CosMx
+        if platform == 'cosmx':
+            # Load technology-specific fields
+            raw = CosMxTranscriptFields()
+
+            # Standardize compartment labels
+            lf = lf.with_columns(
+                pl.col(raw.compartment)
+                .replace_strict(
+                    {
+                        raw.nucleus_value: std.nucleus_value,
+                        raw.membrane_value: std.cytoplasmic_value,
+                        raw.cytoplasmic_value: std.cytoplasmic_value,
+                        raw.extracellular_value: std.extracellular_value,
+                        None: std.extracellular_value,
+                    },
+                    return_dtype=pl.Int8,
+                )
+                .alias(std.compartment)
+            )
+
+            # Standardize cell IDs
+            lf = lf.with_columns(
+                pl.when(pl.col(std.compartment) != std.extracellular_value)
+                .then(pl.col(raw.cell_id))
+                .otherwise(None)
+                .alias(std.cell_id)
             )
 
         if normalize:
@@ -383,10 +420,10 @@ class SpatialDataLoader:
                 select_cols.append(std.quality)
             if cell_id_col:
                 select_cols.append(std.cell_id)
-            # Xenium columns
-            if platform == 'xenium':
-                select_cols.append(std.compartment)  # integrated only in Xenium
-                select_cols.append(raw.is_gene)  # for filtering
+            if platform in ['xenium', 'cosmx']:
+                select_cols.append(std.compartment)
+                if platform == 'xenium':
+                    select_cols.append(raw.is_gene)  # for filtering
 
             # Only select columns that exist after renaming
             schema = lf.collect_schema()
@@ -399,14 +436,6 @@ class SpatialDataLoader:
                     else pl.col(c)
                     for c in select_cols
                 ]
-            )
-
-            # Standardize cell IDs (this allows the filtering in setup_anndata() to catch 'UNASSIGNED' properly
-            lf = lf.with_columns(
-                pl.col(raw.cell_id)
-                .cast(pl.Utf8)
-                .replace(raw.null_cell_id, None)
-                .alias(std.cell_id)
             )
 
         return lf
@@ -474,6 +503,8 @@ class SpatialDataLoader:
                     gdf[std.id] = gdf.index
                 else:
                     gdf[std.id] = range(len(gdf))
+
+                gdf[std.id] = gdf[std.id].astype(str)  # uniform dtype
 
             # Add boundary type
             gdf[std.boundary_type] = bt

--- a/src/segger/validation/me_genes.py
+++ b/src/segger/validation/me_genes.py
@@ -20,6 +20,7 @@ import anndata as ad
 import scanpy as sc
 import pandas as pd
 from itertools import combinations
+from collections import Counter
 
 
 def find_markers(
@@ -137,11 +138,12 @@ def find_mutually_exclusive_genes(
                 all_exclusive.append(gene)
 
     # Get unique exclusive genes
-    unique_genes = list(set(all_exclusive))
+    gene_counts = Counter(all_exclusive)
+    duplicate_genes = {g for g, c in gene_counts.items() if c > 1}
     filtered_exclusive_genes = {
-        ct: [g for g in genes if g in unique_genes]
+        ct: [g for g in genes if g not in duplicate_genes]
         for ct, genes in exclusive_genes.items()
-    }
+        }
 
     # Create pairs from different cell types
     mutually_exclusive_gene_pairs = [


### PR DESCRIPTION
### Change 1 – `ISTDataModule._load_from_spatialdata`

1. Fixed missing/non-visible imports.
2. Quality filtering is no longer conditioned on `self.min_qv`. This ensures that removal of non-gene transcripts is performed and skips QV filtering when not required or possible, given that the appropriate filter is retrieved automatically via `SpatialDataQualityFilter` based on the platform.

---

### Change 2 – `SpatialDataLoader`

The class now implements preprocessing steps previously missing. These steps are normally performed by the `"Technology"Preprocessor` class returned by `get_preprocessor()` in `ISTDataModule.load()`.

The reason is that `get_preprocessor()` infers the platform from the input structure. This information is lost when using `SpatialData` input, making the preprocessor unusable directly. The missing steps are now implemented based on the technology detected.

---

### Change 3 – `AnnDataWriter` / `SpatialDataWriter.write()`

Calls to `write()` in `cli/main.py` do not explicitly handle overwriting. By default, writing would fail if the file already existed.

If `overwrite` is not explicitly passed, its value is determined automatically: existing files are now overwritten. A warning may be added in the future.

---

### Change 4 – `SpatialDataWriter`

Updated element names in the `SpatialData` object and API calls to be compatible with newer versions.

---

### Change 5 – `XeniumTranscriptField` and `XeniumQualityFilter` classes

1. **`null_cell_id`**
Now represented as a tuple: `('UNASSIGNED', '-1')`. Older Xenium versions (e.g., 1.0.0) use `-1` as an integer.
 
Values are cast to strings for consistent comparison with the tuple.  All cell IDs must be aligned to strings elsewhere in the code. Consider if compatibility with older versions is required.

2. **`is_gene` field**
Added to detect gene columns in newer Xenium data and enable filtering transcripts without relying on specific name patterns.

---

### Change 6  – `find_mutually_exclusive_genes`
Fixed filtering behavior: now filtering ensures cell types do not share ME genes, which prevents same-gene pairs to emerge in the MECR computation.
