### PR TITLE
Fix invalid geometries in Xenium nucleus segmentation before intersec…

### DIFF
--- a/src/segger/io/preprocessor.py
+++ b/src/segger/io/preprocessor.py
@@ -980,6 +980,9 @@ class XeniumPreprocessor(ISTPreprocessor):
         # 10X Xenium nucleus segmentation is intersection of geometries
         idx = cells.index.intersection(nuclei.index)
         if len(idx) > 0 and has_cell and has_nuc:
+            import shapely
+            cells.loc[idx, cells.geometry.name] = shapely.make_valid(cells.loc[idx].geometry)
+            nuclei.loc[idx, nuclei.geometry.name] = shapely.make_valid(nuclei.loc[idx].geometry)
             _ = cells.loc[idx].intersection(nuclei.loc[idx])
 
         if len(cells) == 0 and len(nuclei) > 0:


### PR DESCRIPTION
## Summary

- Applies `shapely.make_valid()` to both cell and nuclei geometries before computing their intersection in `XeniumPreprocessor._process_boundaries()`
- Fixes crashes caused by topologically invalid geometries (e.g., self-intersections) in 10X Xenium boundary data

## Problem

When processing Xenium data, the `cells.loc[idx].intersection(nuclei.loc[idx])` call can fail with a `GEOSException` if any of the input geometries are invalid. This is a known issue with real-world polygon data from 10X Xenium outputs.

## Fix

Call `shapely.make_valid()` on both `cells` and `nuclei` geometries right before the intersection, ensuring all polygons have valid topology.