### PR TITLE
Debugged spatialdata writer with refactored shapes

### DIFF
--- a/src/segger/data/utils/heterodata.py
+++ b/src/segger/data/utils/heterodata.py
@@ -48,8 +48,12 @@ def setup_heterodata(
         tx_fields.cell_cluster,
         tx_fields.gene_cluster,
     ]
+
+    # Convert feature_name from cat to string for joining
+    if transcripts[tx_fields.feature].dtype != pl.Utf8:
+        transcripts = transcripts.with_columns(pl.col(tx_fields.feature).cast(pl.Utf8))
+
     # Update transcripts with fields for training
-    
     transcripts = (
         transcripts
         # Reset columns

--- a/src/segger/export/boundary.py
+++ b/src/segger/export/boundary.py
@@ -461,9 +461,9 @@ def generate_boundaries(
 
     def _compute_one(item: Tuple[object, np.ndarray]) -> Tuple[object, int, Union[Polygon, MultiPolygon, None]]:
         cid, points = item
-        n_points = points.shape[0]
-        if n_points < 3:
-            return cid, n_points, None
+        n_unique_points = np.unique(points, axis=0).shape[0]
+        if n_unique_points < 3:
+            return cid, n_unique_points, None
         try:
             bi = BoundaryIdentification(points)
             bi.calculate_part_1(plot=False)
@@ -471,7 +471,7 @@ def generate_boundaries(
             geom = bi.find_cycles()
         except Exception:
             geom = None
-        return cid, n_points, geom
+        return cid, n_unique_points, geom
 
     group_iter, total = iter_groups()
     res = []

--- a/src/segger/export/spatialdata_writer.py
+++ b/src/segger/export/spatialdata_writer.py
@@ -26,6 +26,7 @@ Requires the spatialdata optional dependency:
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional
 
@@ -93,8 +94,8 @@ class SpatialDataWriter:
         shapes_key: str = "cells",
         fragment_shapes_key: str = "fragments",
         include_table: bool = True,
-        table_key: str = "cells",
-        fragment_table_key: str = "fragments",
+        table_key: str = "cells_table",  # no duplicate names allowed
+        fragment_table_key: str = "fragments_table",
         table_region_key: str = "cell_id",
     ):
         require_spatialdata()
@@ -249,6 +250,7 @@ class SpatialDataWriter:
         """Create SpatialData object from transcripts and boundaries."""
         import spatialdata
         from spatialdata.models import PointsModel, ShapesModel, TableModel
+        import spatialdata.models._accessor  # for points parsing on pre-release (https://github.com/scverse/spatialdata/issues/1093)
         import dask.dataframe as dd
 
         identity = self._identity_transform()
@@ -269,7 +271,10 @@ class SpatialDataWriter:
 
         # SOPA expects "cell_id" assignment in points.
         if cell_id_column in tx_pd.columns and "cell_id" not in tx_pd.columns:
-            tx_pd["cell_id"] = tx_pd[cell_id_column]
+            tx_pd['cell_id']= tx_pd[cell_id_column]
+        #NOTE: having both 'cell_id' and 'segger_cell_id' creates confusion     
+        # tx_pd = tx_pd.rename(columns={cell_id_column: "cell_id"})
+        # this would be better but fails as later code still relies on cell_id_column
 
         # Check for z-coordinate
         has_z = z_column and z_column in tx_pd.columns
@@ -286,7 +291,7 @@ class SpatialDataWriter:
                 tx_pd[col] = tx_pd[col].astype(float)
 
         # Create Dask DataFrame for points
-        tx_dask = dd.from_pandas(tx_pd, npartitions=1)
+        tx_dask = dd.from_pandas(tx_pd)
 
         # Points element
         points_parse_kwargs = {
@@ -295,37 +300,68 @@ class SpatialDataWriter:
                 "y": y_column,
                 **({"z": z_column} if has_z else {}),
             },
+            "instance_key": cell_id_column,  # or 'cell_id' which is hard-coded now
+            "feature_key": feature_column,
         }
         if transformations is not None:
             points_parse_kwargs["transformations"] = transformations
 
         points = PointsModel.parse(tx_dask, **points_parse_kwargs)
         points_elements = {self.points_key: points}
+
+        # Shapes
+        def _ensure_cell_id(gdf):
+            if gdf is None:
+                return None
+            if "cell_id" in gdf.columns:
+                return gdf
+            if cell_id_column in gdf.columns:
+                gdf = gdf.copy()
+                gdf["cell_id"] = gdf[cell_id_column]
+                return gdf
+            gdf = gdf.reset_index(drop=False)
+            if "cell_id" not in gdf.columns and len(gdf.columns) > 0:
+                gdf["cell_id"] = gdf[gdf.columns[0]]
+            return gdf
+
+
+        def _parse_shapes(shapes):
+            if shapes is None or len(shapes) == 0:
+                return None
+            kwargs = {"transformations": transformations} if transformations is not None else {}
+            return ShapesModel.parse(shapes, **kwargs)
+
+
         shapes_elements = {}
 
-        # Shapes element (if boundaries provided or generated)
         if self.include_boundaries and self.boundary_method != "skip":
-            shape_specs = [(self.shapes_key, cell_tx_pd)]
-            if has_fragments and fragment_tx_pd is not None:
-                shape_specs.append((self.fragment_shapes_key, fragment_tx_pd))
-            for shape_key, shape_tx_pd in shape_specs:
-                shapes = self._get_boundaries(
-                    transcripts=shape_tx_pd,
-                    boundaries=boundaries,
-                    x_column=x_column,
-                    y_column=y_column,
-                    cell_id_column=cell_id_column,
-                )
-                if shapes is not None and len(shapes) > 0:
-                    shapes_parse_kwargs = {}
-                    if transformations is not None:
-                        shapes_parse_kwargs["transformations"] = transformations
-                    shapes_parsed = ShapesModel.parse(shapes, **shapes_parse_kwargs)
-                    shapes_elements[shape_key] = shapes_parsed
+            if self.boundary_method == "input":
+                for bd_type in ["cell", "nucleus"]:  # these are segger hard-coded
+                    shapes = self._get_input_boundaries(
+                        cell_tx_pd,
+                        cell_id_column,
+                        boundaries,
+                        bd_type)
+                    shapes = _ensure_cell_id(shapes)
+                    parsed = _parse_shapes(shapes)
+                    if parsed is not None:
+                        shapes_elements[f"{bd_type}_boundaries"] = parsed  
+                        # this naming convention is very Xenium-based (ideally one would maintain the input one which is currently lost)
+            else:
+                shape_specs = [(self.shapes_key, cell_tx_pd)]
+                if has_fragments and fragment_tx_pd is not None:
+                    shape_specs.append((self.fragment_shapes_key, fragment_tx_pd))
 
-        tables_elements = {}
+                for shape_key, shape_tx_pd in shape_specs:
+                    shapes = self._get_generated_boundaries(shape_tx_pd, x_column, y_column, cell_id_column)
+                    shapes = _ensure_cell_id(shapes)
+                    parsed = _parse_shapes(shapes)
+                    if parsed is not None:
+                        shapes_elements[shape_key] = parsed
+                
 
         # Optional AnnData table
+        tables_elements = {}
         if self.include_table:
             tables_elements[self.table_key] = self._build_table_element(
                 TableModel=TableModel,
@@ -355,12 +391,12 @@ class SpatialDataWriter:
                     z_column=z_column,
                 )
 
-        # Create SpatialData (prefer modern constructor methods, keep fallback)
+        # Create SpatialData (prefer modern constructor methods, keep fallback on single elemnts)
         sdata = self._build_spatialdata(
             spatialdata=spatialdata,
-            points=points_elements,
-            shapes=shapes_elements,
-            tables=tables_elements,
+            points_elements=points_elements,
+            shapes_elements=shapes_elements,
+            tables_elements=tables_elements,
         )
 
         return sdata
@@ -373,34 +409,18 @@ class SpatialDataWriter:
         except Exception:
             return None
 
-    def _build_spatialdata(self, spatialdata, points: dict, shapes: dict, tables: dict):
+    def _build_spatialdata(self, spatialdata, points_elements: dict, shapes_elements: dict, tables_elements: dict):
         """Build a SpatialData object across SpatialData API variants."""
-        shapes_arg = shapes or None
-        tables_arg = tables or None
 
         if hasattr(spatialdata.SpatialData, "init_from_elements"):
-            return spatialdata.SpatialData.init_from_elements(
-                points=points,
-                shapes=shapes_arg,
-                tables=tables_arg,
-            )
-
-        try:
+            return spatialdata.SpatialData.init_from_elements(points_elements | shapes_elements | tables_elements)
+        else:
             return spatialdata.SpatialData(
-                points=points,
-                shapes=shapes_arg,
-                tables=tables_arg,
+                points=points_elements,
+                shapes=shapes_elements,
+                tables=tables_elements,
             )
-        except Exception:
-            elements = {}
-            for key, value in points.items():
-                elements[f"points/{key}"] = value
-            for key, value in shapes.items():
-                elements[f"shapes/{key}"] = value
-            sdata = spatialdata.SpatialData.from_elements_dict(elements)
-            for key, value in (tables or {}).items():
-                sdata.tables[key] = value
-            return sdata
+      
 
     def _build_table_element(
         self,
@@ -458,81 +478,63 @@ class SpatialDataWriter:
             shutil.rmtree(output_path)
         sdata.write(output_path)
 
-    def _get_boundaries(
+
+    
+    def _get_input_boundaries(self, cell_tx_pd, cell_id_column, boundaries, bd_type):
+
+        selected_ids = cell_tx_pd[cell_id_column].dropna().unique()
+        if len(selected_ids) == 0 or boundaries is None:
+            if boundaries is None:
+                warnings.warn("No input boundaries were found. Skipping boundary generation.")
+            return None
+
+        boundaries_filtered = boundaries.loc[boundaries['boundary_type'] == bd_type]
+        boundaries_gdf = boundaries_filtered[boundaries_filtered["cell_id"].isin(selected_ids)].copy()
+
+        return boundaries_gdf if not boundaries_gdf.empty else None
+            
+    
+
+    def _get_generated_boundaries(
         self,
-        transcripts: "pd.DataFrame",
-        boundaries: Optional["gpd.GeoDataFrame"],
+        transcripts: pd.DataFrame,
         x_column: str,
         y_column: str,
         cell_id_column: str,
-    ) -> Optional["gpd.GeoDataFrame"]:
-        """Get or generate cell boundaries."""
+    ) -> Optional[gpd.GeoDataFrame]:
+        """Generate cell boundaries based on the selected boundary method.
+            Args
+                transcripts: dataframe of group transcripts (cells or fragments)
+                x_column, y_column: transcripts 2D coordinates
+                cell_id_column: cell ID
+        """
         import geopandas as gpd
-        import pandas as pd
-        from shapely.geometry import MultiPoint
-
-        def _ensure_cell_id(gdf: "gpd.GeoDataFrame") -> "gpd.GeoDataFrame":
-            if "cell_id" in gdf.columns:
-                return gdf
-            if cell_id_column in gdf.columns:
-                gdf = gdf.copy()
-                gdf["cell_id"] = gdf[cell_id_column]
-                return gdf
-            gdf = gdf.reset_index(drop=False)
-            if "cell_id" not in gdf.columns and len(gdf.columns) > 0:
-                gdf["cell_id"] = gdf[gdf.columns[0]]
-            return gdf
-
-        # Use input boundaries if available
-        if boundaries is not None:
-            filtered = _ensure_cell_id(boundaries)
-            if len(transcripts) == 0:
-                return filtered.iloc[0:0].copy()
-            selected_ids = transcripts[cell_id_column].dropna().unique()
-            return filtered[filtered["cell_id"].isin(selected_ids)].copy()
-
-        # Generate boundaries based on method
-        if self.boundary_method == "input":
-            # No input boundaries, skip
+        
+        assigned = transcripts[transcripts[cell_id_column] != -1].copy()
+        if assigned.empty:
             return None
 
-        elif self.boundary_method == "convex_hull":
-            # Generate convex hulls from transcript positions
-            assigned = transcripts[transcripts[cell_id_column] != -1].copy()
+        if self.boundary_method == "convex_hull":
+            from shapely.geometry import MultiPoint
 
-            if len(assigned) == 0:
-                return None
-
-            # Group by cell and create convex hulls
-            hulls = []
-            cell_ids = []
+            hulls, cell_ids = [], []
 
             for cell_id, group in assigned.groupby(cell_id_column):
                 if len(group) < 3:
-                    continue  # Need at least 3 points for convex hull
-
+                    continue
                 points = list(zip(group[x_column], group[y_column]))
-                mp = MultiPoint(points)
-                hull = mp.convex_hull
-
-                if not hull.is_empty:
-                    hulls.append(hull)
-                    cell_ids.append(cell_id)
+                hull = MultiPoint(points).convex_hull
+                if hull.is_empty or hull.geom_type != "Polygon":
+                    continue
+                hulls.append(hull)
+                cell_ids.append(cell_id)
 
             if not hulls:
                 return None
-
-            return _ensure_cell_id(gpd.GeoDataFrame(
-                {"cell_id": cell_ids},
-                geometry=hulls,
-            ))
+            return gpd.GeoDataFrame({"cell_id": cell_ids}, geometry=hulls)
 
         elif self.boundary_method == "delaunay":
             from segger.export.boundary import generate_boundaries
-
-            assigned = transcripts[transcripts[cell_id_column] != -1].copy()
-            if len(assigned) == 0:
-                return None
 
             boundaries_gdf = generate_boundaries(
                 assigned,
@@ -541,9 +543,12 @@ class SpatialDataWriter:
                 cell_id=cell_id_column,
                 n_jobs=self.boundary_n_jobs,
             )
-            if boundaries_gdf is None or len(boundaries_gdf) == 0:
+            boundaries_gdf = boundaries_gdf[
+                boundaries_gdf.geometry.notna() & ~boundaries_gdf.geometry.is_empty
+            ]
+            if len(boundaries_gdf) == 0:
                 return None
-            return _ensure_cell_id(boundaries_gdf)
+            return boundaries_gdf
 
         return None
 


### PR DESCRIPTION
The main issues identified during debugging relate to the initialization of the `SpatialData` object with dictionaries and to writing. I also fixed cases in boundary generation with convex hull/delaunay  where an ID has three or more points but the corresponding coordinates do not actually form a valid polygon (points coincide).

I slightly refactored the shapes element creation by separating concerns: one helper function for input boundaries, called separately for cell and nucleus boundaries, and one for generated boundaries, called iteratively for cells and fragments.

