### PR TITLE
[integration/peerlab] feature: adding a reference gene correlation

### DIFF
--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -78,17 +78,6 @@ def segment(
         validator=validators.Path(exists=True, dir_okay=True),
     )] = registry.get_default("output_directory"),
     
-    gene_corr_reference_path: Annotated[Path | None, Parameter(
-        help=(
-            "Path to a reference AnnData .h5ad file used to compute the shared "
-            "gene-gene correlation matrix. Must have a 'norm' layer with "
-            "pre-normalized counts and must contain all genes present in the "
-            "sample after filtering. If not provided, the correlation matrix "
-            "is computed per-sample."
-        ),
-        group=group_io,
-    )] = None,
-
     # Cell Representation
     node_representation_dim: Annotated[int, Parameter(
         help="Number of dimensions used to represent each node type.",
@@ -133,6 +122,20 @@ def segment(
         validator=validators.Number(gt=0, lte=5),
         group=group_nodes,
     )] = registry.get_default("genes_clusters_resolution"),
+
+    gene_corr_reference_path: Annotated[Path | None, Parameter(
+        help=(
+            "Path to a reference AnnData .h5ad file used to compute a shared "
+            "gene-gene correlation matrix."
+        ),
+        group=group_nodes,
+    )] = None,
+
+
+    gene_missing_strategy: Annotated[Literal["error", "remove", "fill"], registry.get_parameter(
+        "gene_missing_strategy",
+        group=group_nodes,
+    )] = registry.get_default("gene_missing_strategy"),
 
 
     # Transcript-Transcript Graph
@@ -300,11 +303,6 @@ def segment(
     )] = registry.get_default("sg_weight_end"),
 
     # Reference
-    gene_missing_strategy: Annotated[Literal["error", "remove", "fill"], registry.get_parameter(
-        "gene_missing_strategy",
-        group=group_io,
-    )] = registry.get_default("gene_missing_strategy"),
-
     save_anndata: Annotated[bool, registry.get_parameter(
         "save_anndata",
         group=group_io,

--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -299,6 +299,12 @@ def segment(
         group=group_loss,
     )] = registry.get_default("sg_weight_end"),
 
+    # Reference
+    gene_missing_strategy: Annotated[Literal["error", "remove", "fill"], registry.get_parameter(
+        "gene_missing_strategy",
+        group=group_io,
+    )] = registry.get_default("gene_missing_strategy"),
+
     save_anndata: Annotated[bool, registry.get_parameter(
         "save_anndata",
         group=group_io,
@@ -338,7 +344,8 @@ def segment(
         tiling_margin_prediction=tiling_margin_prediction,
         tiling_nodes_per_tile=max_nodes_per_tile,
         edges_per_batch=max_edges_per_batch,
-        gene_corr_reference_path = gene_corr_reference_path 
+        gene_corr_reference_path=gene_corr_reference_path,
+        gene_missing_strategy=gene_missing_strategy,
     )
     
     # Setup Lightning Model

--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -78,6 +78,18 @@ def segment(
         validator=validators.Path(exists=True, dir_okay=True),
     )] = registry.get_default("output_directory"),
     
+    #NEWLY ADDED: ---------------------------------------------
+    gene_corr_reference_path: Annotated[Path | None, Parameter(
+        help=(
+            "Path to a reference AnnData .h5ad file used to compute the shared "
+            "gene-gene correlation matrix. Must have a 'norm' layer with "
+            "pre-normalized counts and must contain all genes present in the "
+            "sample after filtering. If not provided, the correlation matrix "
+            "is computed per-sample."
+        ),
+        group=group_io,
+    )] = None,
+    #---------------------------------------------------------------
 
     # Cell Representation
     node_representation_dim: Annotated[int, Parameter(
@@ -328,6 +340,7 @@ def segment(
         tiling_margin_prediction=tiling_margin_prediction,
         tiling_nodes_per_tile=max_nodes_per_tile,
         edges_per_batch=max_edges_per_batch,
+        gene_corr_reference_path = gene_corr_reference_path #ADDED
     )
     
     # Setup Lightning Model

--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -78,7 +78,6 @@ def segment(
         validator=validators.Path(exists=True, dir_okay=True),
     )] = registry.get_default("output_directory"),
     
-    #NEWLY ADDED: ---------------------------------------------
     gene_corr_reference_path: Annotated[Path | None, Parameter(
         help=(
             "Path to a reference AnnData .h5ad file used to compute the shared "
@@ -89,7 +88,6 @@ def segment(
         ),
         group=group_io,
     )] = None,
-    #---------------------------------------------------------------
 
     # Cell Representation
     node_representation_dim: Annotated[int, Parameter(
@@ -340,7 +338,7 @@ def segment(
         tiling_margin_prediction=tiling_margin_prediction,
         tiling_nodes_per_tile=max_nodes_per_tile,
         edges_per_batch=max_edges_per_batch,
-        gene_corr_reference_path = gene_corr_reference_path #ADDED
+        gene_corr_reference_path = gene_corr_reference_path 
     )
     
     # Setup Lightning Model

--- a/src/segger/data/data_module.py
+++ b/src/segger/data/data_module.py
@@ -6,6 +6,7 @@ from lightning.pytorch import LightningDataModule
 from torchvision.transforms import Compose
 from dataclasses import dataclass
 from typing import Literal
+import scanpy as sc
 from pathlib import Path
 import polars as pl
 import torch
@@ -125,6 +126,7 @@ class ISTDataModule(LightningDataModule):
         Fraction of tiles used for training; the rest for validation.
     edges_per_batch : int, default=1_000_000
         Maximum number of edges per batch in the DataLoader.
+    gene_corr_reference : sc.AnnData or None, default=None
     """
     input_directory: Path
     num_workers: int = 8
@@ -150,6 +152,7 @@ class ISTDataModule(LightningDataModule):
     tiling_side_length: float = 250.  # TODO: Remove (benchmarking only)
     training_fraction: float = 0.75
     edges_per_batch: int = 1_000_000
+    gene_corr_reference_path: Path | None = None #ADDED
     
     def __post_init__(self):
         """TODO: Description
@@ -190,6 +193,10 @@ class ISTDataModule(LightningDataModule):
         tx_mask = pl.col(tx_fields.compartment).is_in(compartments)
         bd_mask = bd[bd_fields.boundary_type] == boundary_type
 
+
+        #NEWLY ADDED: load in the reference anndata if provided-------------------------------------
+        gene_corr_reference = sc.read_h5ad(self.gene_corr_reference_path) if self.gene_corr_reference_path is not None else None
+
         # Generate reference AnnData
         self.logger.debug("Generating reference AnnData object...")
         self.ad = setup_anndata(
@@ -204,6 +211,8 @@ class ISTDataModule(LightningDataModule):
             genes_clusters_n_neighbors=self.genes_clusters_n_neighbors,
             genes_clusters_resolution=self.genes_clusters_resolution,
             compute_morphology=(self.cells_representation_mode == "morphology"),
+            gene_corr_reference = gene_corr_reference #ADDED
+
         )
 
         self.logger.debug("Setting up HeteroData object...")

--- a/src/segger/data/data_module.py
+++ b/src/segger/data/data_module.py
@@ -127,6 +127,9 @@ class ISTDataModule(LightningDataModule):
     edges_per_batch : int, default=1_000_000
         Maximum number of edges per batch in the DataLoader.
     gene_corr_reference : sc.AnnData or None, default=None
+        Optional reference AnnData object used to compute gene-gene correlation features.
+    gene_missing_strategy : {"error", "warn", "remove", "fill"}, default="error"
+        Strategy for handling genes present in the data but missing from the reference.
     """
     input_directory: Path
     num_workers: int = 8
@@ -153,6 +156,7 @@ class ISTDataModule(LightningDataModule):
     training_fraction: float = 0.75
     edges_per_batch: int = 1_000_000
     gene_corr_reference_path: Path | None = None 
+    gene_missing_strategy: Literal["error", "remove", "fill"] = "error"
     
     def __post_init__(self):
         """TODO: Description
@@ -210,7 +214,8 @@ class ISTDataModule(LightningDataModule):
             genes_clusters_n_neighbors=self.genes_clusters_n_neighbors,
             genes_clusters_resolution=self.genes_clusters_resolution,
             compute_morphology=(self.cells_representation_mode == "morphology"),
-            gene_corr_reference = gene_corr_reference 
+            gene_corr_reference = gene_corr_reference,
+            gene_missing_strategy = gene_missing_strategy,
 
         )
 

--- a/src/segger/data/data_module.py
+++ b/src/segger/data/data_module.py
@@ -214,8 +214,8 @@ class ISTDataModule(LightningDataModule):
             genes_clusters_n_neighbors=self.genes_clusters_n_neighbors,
             genes_clusters_resolution=self.genes_clusters_resolution,
             compute_morphology=(self.cells_representation_mode == "morphology"),
-            gene_corr_reference = gene_corr_reference,
-            gene_missing_strategy = gene_missing_strategy,
+            gene_corr_reference=gene_corr_reference,
+            gene_missing_strategy=self.gene_missing_strategy,
 
         )
 

--- a/src/segger/data/data_module.py
+++ b/src/segger/data/data_module.py
@@ -152,7 +152,7 @@ class ISTDataModule(LightningDataModule):
     tiling_side_length: float = 250.  # TODO: Remove (benchmarking only)
     training_fraction: float = 0.75
     edges_per_batch: int = 1_000_000
-    gene_corr_reference_path: Path | None = None #ADDED
+    gene_corr_reference_path: Path | None = None 
     
     def __post_init__(self):
         """TODO: Description
@@ -194,7 +194,6 @@ class ISTDataModule(LightningDataModule):
         bd_mask = bd[bd_fields.boundary_type] == boundary_type
 
 
-        #NEWLY ADDED: load in the reference anndata if provided-------------------------------------
         gene_corr_reference = sc.read_h5ad(self.gene_corr_reference_path) if self.gene_corr_reference_path is not None else None
 
         # Generate reference AnnData
@@ -211,7 +210,7 @@ class ISTDataModule(LightningDataModule):
             genes_clusters_n_neighbors=self.genes_clusters_n_neighbors,
             genes_clusters_resolution=self.genes_clusters_resolution,
             compute_morphology=(self.cells_representation_mode == "morphology"),
-            gene_corr_reference = gene_corr_reference #ADDED
+            gene_corr_reference = gene_corr_reference 
 
         )
 

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -181,13 +181,27 @@ def setup_anndata(
     # Explicitly sort indices for reproducibility
     ad = ad[ad.obs.index.sort_values(), ad.var.index.sort_values()]
 
-    #NEW ADDITIONS: -------------------------------------------------------------------
-    #if gene corr reference is passed in, ensure it has normalized counts, and ensure reference is not missing any genes (reference should be filtered by min_counts)
+
     if gene_corr_reference is not None:
+
         assert set(ad.var.index) <= set(gene_corr_reference.var.index), ("gene_corr_reference is missing genes present in this sample")
-        assert 'norm' in gene_corr_reference.layers, ("gene_corr_reference must have a 'norm' layer with pre normalized counts")
-    
-    #------------------------------------------------------------------------------
+
+        #ensure the gene_corr_reference contains raw counts:
+        assert gene_corr_reference.X.dtype in (np.int32, np.int64), "X does not contain raw counts"        
+        #normalize counts based on filtered cells to create 'norm' layer (like below)
+        gene_corr_reference.obs['n_counts'] = gene_corr_reference.X.sum(1).A.flatten()
+        gene_corr_reference.obs['filtered'] = gene_corr_reference.obs['n_counts'] >= cells_min_counts
+        gene_corr_reference.layers['norm'] = gene_corr_reference.X.copy()
+        target_sum = gene_corr_reference.obs.loc[gene_corr_reference.obs['filtered'], 'n_counts'].median()
+        sc.pp.normalize_total(gene_corr_reference, target_sum=target_sum, layer='norm')
+
+
+
+        #assert that all genes in gene_corr_reference pass the genes_min_counts threshold set by segger
+        gene_corr_reference.var['n_counts'] = gene_corr_reference.X.sum(0).A.flatten()
+        failing_genes = gene_corr_reference.var[gene_corr_reference.var['n_counts'] < genes_min_counts]
+        assert len(failing_genes) == 0, (f"{len(failing_genes)} in gene_corr_reference fail the genes_min_counts threshold.")
+
 
     # Add raw counts
     ad.raw = ad.copy()
@@ -202,7 +216,6 @@ def setup_anndata(
     target_sum = ad.obs.loc[ad.obs['filtered'], 'n_counts'].median()
     sc.pp.normalize_total(ad, target_sum=target_sum, layer='norm')
 
-    #NEW ADDITIONS: -------------------------------------------------------------------
     if gene_corr_reference is not None:
         #put reference genes in same order as sample genes
         ref = gene_corr_reference[:, ad.var.index]

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -214,7 +214,7 @@ def setup_anndata(
     #create gene gene correlation matrix, and run pca on that to create the gene embeddings 
     C = np.corrcoef(np.asarray(counts.todense()).T)
     C = np.nan_to_num(C, 0, posinf=True, neginf=True)
-    model = sklearn.decomposition.PCA(n_components=cells_embedding_size)
+    model = sklearn.decomposition.PCA(n_components=cells_embedding_size, random_state=0)
     ad.varm['X_corr'] = model.fit_transform(C)
     #---------------------------------------------------------------------------------
 
@@ -226,7 +226,7 @@ def setup_anndata(
 
     # Build PCs on filtered cells and project all cells
     counts_sparse_gpu = cupyx.scipy.sparse.csr_matrix(ad.layers['norm'])
-    model = cuml.PCA(n_components=cells_embedding_size)
+    model = cuml.PCA(n_components=cells_embedding_size, random_state=0)
     model.fit(counts_sparse_gpu[ad.obs['filtered'].values])
     ad.obsm['X_pca'] = model.transform(counts_sparse_gpu).get()
 

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -184,8 +184,9 @@ def setup_anndata(
     #NEW ADDITIONS: -------------------------------------------------------------------
     #if gene corr reference is passed in, ensure it has normalized counts, and ensure reference is not missing any genes (reference should be filtered by min_counts)
     if gene_corr_reference is not None:
-        # assert set(ad.var.index) <= set(gene_corr_reference.var.index), ("gene_corr_reference is missing genes present in this sample")
+        assert set(ad.var.index) <= set(gene_corr_reference.var.index), ("gene_corr_reference is missing genes present in this sample")
         assert 'norm' in gene_corr_reference.layers, ("gene_corr_reference must have a 'norm' layer with pre normalized counts")
+    
     #------------------------------------------------------------------------------
 
     # Add raw counts
@@ -203,23 +204,13 @@ def setup_anndata(
 
     #NEW ADDITIONS: -------------------------------------------------------------------
     if gene_corr_reference is not None:
-        if set(ad.var.index) != set(gene_corr_reference.var.index):
-            print("Warning: some of the genes present in this sample are not present in the gene correlation reference or visa versa.")
-            genes_not_in_reference = set(ad.var.index) - set(gene_corr_reference.var.index)
-            print("The following genes are present in this sample but not in the gene correlation reference:", genes_not_in_reference)
-
-            #put reference genes in same order as sample genes
-            ref = gene_corr_reference[:, ad.var.index]
-            counts = ref.layers['norm']
-            for gene in genes_not_in_reference:
-                counts.append(ad.layers['norm'][:, ad.var.index.get_loc(gene)])
-        else: 
-            ref = gene_corr_reference[:, ad.var.index]
-            counts = ref.layers['norm']
+        #put reference genes in same order as sample genes
+        ref = gene_corr_reference[:, ad.var.index]
+        counts = ref.layers['norm']
     else:
         #create counts from the sample the same way
         counts = ad[ad.obs['filtered']].layers['norm']
-
+    
     #create gene gene correlation matrix, and run pca on that to create the gene embeddings 
     C = np.corrcoef(np.asarray(counts.todense()).T)
     C = np.nan_to_num(C, 0, posinf=True, neginf=True)

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -1,3 +1,5 @@
+from email.message import Message
+
 from torch.nn.functional import normalize
 from scipy import sparse as sp
 import geopandas as gpd
@@ -130,7 +132,7 @@ def get_cluster_cosine_similarity(
 def setup_anndata(
     transcripts: pl.DataFrame,
     boundaries: gpd.GeoDataFrame,
-    cell_column: str,
+    cell_column: str, 
     cells_embedding_size: int,
     cells_min_counts: int,
     cells_clusters_n_neighbors: int,
@@ -139,9 +141,9 @@ def setup_anndata(
     genes_clusters_n_neighbors: int,
     genes_clusters_resolution: float,
     compute_morphology: bool = False,
+    gene_corr_reference: sc.AnnData | None = None,
 ):
-    """TODO: Add description.
-    """
+    """TODO: Add description."""
     # Standard fields
     tx_fields = TrainingTranscriptFields()
     bd_fields = TrainingBoundaryFields()
@@ -178,7 +180,14 @@ def setup_anndata(
 
     # Explicitly sort indices for reproducibility
     ad = ad[ad.obs.index.sort_values(), ad.var.index.sort_values()]
-    
+
+    #NEW ADDITIONS: -------------------------------------------------------------------
+    #if gene corr reference is passed in, ensure it has normalized counts, and ensure reference is not missing any genes (reference should be filtered by min_counts)
+    if gene_corr_reference is not None:
+        # assert set(ad.var.index) <= set(gene_corr_reference.var.index), ("gene_corr_reference is missing genes present in this sample")
+        assert 'norm' in gene_corr_reference.layers, ("gene_corr_reference must have a 'norm' layer with pre normalized counts")
+    #------------------------------------------------------------------------------
+
     # Add raw counts
     ad.raw = ad.copy()
     ad.layers['counts'] = ad.raw.X.copy()
@@ -192,11 +201,37 @@ def setup_anndata(
     target_sum = ad.obs.loc[ad.obs['filtered'], 'n_counts'].median()
     sc.pp.normalize_total(ad, target_sum=target_sum, layer='norm')
 
-    # Build gene embedding on filtered dataset
-    C = np.corrcoef(ad[ad.obs['filtered']].layers['norm'].todense().T)
+    #NEW ADDITIONS: -------------------------------------------------------------------
+    if gene_corr_reference is not None:
+        if set(ad.var.index) != set(gene_corr_reference.var.index):
+            print("Warning: some of the genes present in this sample are not present in the gene correlation reference or visa versa.")
+            genes_not_in_reference = set(ad.var.index) - set(gene_corr_reference.var.index)
+            print("The following genes are present in this sample but not in the gene correlation reference:", genes_not_in_reference)
+
+            #put reference genes in same order as sample genes
+            ref = gene_corr_reference[:, ad.var.index]
+            counts = ref.layers['norm']
+            for gene in genes_not_in_reference:
+                counts.append(ad.layers['norm'][:, ad.var.index.get_loc(gene)])
+        else: 
+            ref = gene_corr_reference[:, ad.var.index]
+            counts = ref.layers['norm']
+    else:
+        #create counts from the sample the same way
+        counts = ad[ad.obs['filtered']].layers['norm']
+
+    #create gene gene correlation matrix, and run pca on that to create the gene embeddings 
+    C = np.corrcoef(np.asarray(counts.todense()).T)
     C = np.nan_to_num(C, 0, posinf=True, neginf=True)
     model = sklearn.decomposition.PCA(n_components=cells_embedding_size)
     ad.varm['X_corr'] = model.fit_transform(C)
+    #---------------------------------------------------------------------------------
+
+    # Build gene embedding on filtered dataset
+    #C = np.corrcoef(ad[ad.obs['filtered']].layers['norm'].todense().T)
+    #C = np.nan_to_num(C, 0, posinf=True, neginf=True)
+    #model = sklearn.decomposition.PCA(n_components=cells_embedding_size)
+    #ad.varm['X_corr'] = model.fit_transform(C)
 
     # Build PCs on filtered cells and project all cells
     counts_sparse_gpu = cupyx.scipy.sparse.csr_matrix(ad.layers['norm'])
@@ -207,11 +242,11 @@ def setup_anndata(
     # Compute clusters on filtered cells
     cell_clusters = phenograph_rapids(
         ad[ad.obs['filtered']].obsm['X_pca'],
-        n_neighbors=cells_clusters_n_neighbors, 
+        n_neighbors=cells_clusters_n_neighbors,
         resolution=cells_clusters_resolution,
         min_size=100,
     )
-    ad.obs['phenograph_cluster'] = -1  # removed cells have no cluster
+    ad.obs['phenograph_cluster'] = -1 # removed cells have no cluster
     ad.obs.loc[ad.obs['filtered'], 'phenograph_cluster'] = cell_clusters
     ad.obs['phenograph_cluster'] = pd.Categorical(ad.obs['phenograph_cluster'])
 

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -11,6 +11,7 @@ import sklearn
 import torch
 import cupyx
 import cuml
+import warnings
 
 from ...io.fields import TrainingTranscriptFields, TrainingBoundaryFields
 from .neighbors import phenograph_rapids
@@ -142,6 +143,7 @@ def setup_anndata(
     genes_clusters_resolution: float,
     compute_morphology: bool = False,
     gene_corr_reference: sc.AnnData | None = None,
+    gene_missing_strategy: str = "error",
 ):
     """TODO: Add description."""
     # Standard fields
@@ -212,8 +214,18 @@ def setup_anndata(
             if len(genes_not_in_reference) > 5:
                 msg += f"\n - ... and {len(genes_not_in_reference) - 5} more."
 
-            # TODO: Allow to proceed with missing genes: Add condition for Error below, then impute missing correlations with data.
-            raise ValueError(msg)
+            # Handle missing genes
+            if gene_missing_strategy == "error":
+                raise ValueError(msg)
+            elif gene_missing_strategy == "remove":
+                warnings.warn(msg + "\nThese genes will be removed from the data.")
+                ad = ad[:, ~ad.var.index.isin(genes_not_in_reference)]
+                ad = _normalise(ad) # re-normalise after gene removal
+            elif gene_missing_strategy == "fill":
+                # TODO: Fill missing gene correlations with data-based estimates after line 247(?)
+                raise NotImplementedError("gene_missing_strategy='fill' is not implemented yet.")
+            else:
+                raise ValueError(f"Unknown gene_missing_strategy: {gene_missing_strategy}. Choose from 'error', 'warn', 'ignore', or 'fill'.")
     
         # assert that genes in reference pass count thresholds
         gene_corr_reference.var['n_counts'] = gene_corr_reference.X.sum(0).A.flatten()

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -174,51 +174,57 @@ def setup_anndata(
     )
     assert ~ad.obs.index.isna().any()
 
-    # Remove genes with fewer than min counts permanently
-    ad.var['n_counts'] = ad.X.sum(0).A.flatten()
-    ad = ad[:,  ad.var['n_counts'].ge(genes_min_counts)]
-
     # Explicitly sort indices for reproducibility
     ad = ad[ad.obs.index.sort_values(), ad.var.index.sort_values()]
 
-
-    if gene_corr_reference is not None:
-
-        assert set(ad.var.index) <= set(gene_corr_reference.var.index), ("gene_corr_reference is missing genes present in this sample")
-
-        #ensure the gene_corr_reference contains raw counts:
-        assert gene_corr_reference.X.dtype in (np.int32, np.int64), "X does not contain raw counts"        
-        #normalize counts based on filtered cells to create 'norm' layer (like below)
-        gene_corr_reference.obs['n_counts'] = gene_corr_reference.X.sum(1).A.flatten()
-        gene_corr_reference.obs['filtered'] = gene_corr_reference.obs['n_counts'] >= cells_min_counts
-        gene_corr_reference.layers['norm'] = gene_corr_reference.X.copy()
-        target_sum = gene_corr_reference.obs.loc[gene_corr_reference.obs['filtered'], 'n_counts'].median()
-        sc.pp.normalize_total(gene_corr_reference, target_sum=target_sum, layer='norm')
-
-
-
-        #assert that all genes in gene_corr_reference pass the genes_min_counts threshold set by segger
-        gene_corr_reference.var['n_counts'] = gene_corr_reference.X.sum(0).A.flatten()
-        failing_genes = gene_corr_reference.var[gene_corr_reference.var['n_counts'] < genes_min_counts]
-        assert len(failing_genes) == 0, (f"{len(failing_genes)} in gene_corr_reference fail the genes_min_counts threshold.")
-
+    # Normalise data
+    def _normalise(adata):
+        adata.obs.loc[:, "n_counts"] = adata.X.sum(1).A.flatten()
+        adata.obs.loc[:, "filtered"] = adata.obs["n_counts"].ge(cells_min_counts)
+        adata.layers["norm"] = adata.X.copy()
+        target_sum = adata.obs.loc[adata.obs["filtered"], "n_counts"].median()
+        sc.pp.normalize_total(adata, target_sum=target_sum, layer="norm")
+        return adata
 
     # Add raw counts
     ad.raw = ad.copy()
     ad.layers['counts'] = ad.raw.X.copy()
 
-    # Keep track of filtered cells
-    ad.obs['n_counts'] = ad.raw.X.sum(1).A.flatten()
-    ad.obs['filtered'] = ad.obs['n_counts'].ge(cells_min_counts)
+    # Filter genes and normalise
+    ad.var['n_counts'] = ad.X.sum(0).A.flatten()
+    ad = ad[:,  ad.var['n_counts'].ge(genes_min_counts)]
+    ad = _normalise(ad)
 
-    # Normalize to filtered dataset counts
-    ad.layers['norm'] = ad.layers['counts'].copy()
-    target_sum = ad.obs.loc[ad.obs['filtered'], 'n_counts'].median()
-    sc.pp.normalize_total(ad, target_sum=target_sum, layer='norm')
-
+    # Prepare reference
     if gene_corr_reference is not None:
-        #put reference genes in same order as sample genes
+
+        # assert that reference contains raw counts
+        is_int_dtype = np.issubdtype(gene_corr_reference.X.dtype, np.integer)
+        is_int_value = np.all(gene_corr_reference.X.data.astype(int)[:1e4] == gene_corr_reference.X.data[:1e4])
+        assert is_int_dtype or not is_int_value, "adata_reference.X should contain raw counts, but appears to be normalized. Please provide raw counts for gene_corr_reference.X."      
+
+        # assert that all genes in the data are in the reference too.
+        genes_not_in_reference = set(ad.var.index) - set(gene_corr_reference.var.index)
+        if len(genes_not_in_reference) > 0:
+            msg = f"WARNING: {len(genes_not_in_reference)} genes are in the data, but not in the provided gene correlation reference."
+            for gene in genes_not_in_reference[:5]: # print up to 5 missing genes
+                msg += f"\n - {gene}"
+            if len(genes_not_in_reference) > 5:
+                msg += f"\n - ... and {len(genes_not_in_reference) - 5} more."
+
+            # TODO: Allow to proceed with missing genes: Add condition for Error below, then impute missing correlations with data.
+            raise ValueError(msg)
+    
+        # assert that genes in reference pass count thresholds
+        gene_corr_reference.var['n_counts'] = gene_corr_reference.X.sum(0).A.flatten()
+        failing_genes = gene_corr_reference.var[gene_corr_reference.var['n_counts'] < genes_min_counts]
+        assert len(failing_genes) == 0, (f"{len(failing_genes)} genes in the gene_corr_reference fail the genes_min_counts threshold, including: {', '.join(failing_genes.index[:5])} and {len(failing_genes) - 5} more.")
+
+        # subset and put reference genes in same order as sample genes
         ref = gene_corr_reference[:, ad.var.index]
+
+        # normalise
+        ref = _normalise(ref)
         counts = ref.layers['norm']
     else:
         #create counts from the sample the same way

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -200,7 +200,7 @@ def setup_anndata(
 
         # assert that reference contains raw counts
         is_int_dtype = np.issubdtype(gene_corr_reference.X.dtype, np.integer)
-        is_int_value = np.all(gene_corr_reference.X.data.astype(int)[:1e4] == gene_corr_reference.X.data[:1e4])
+        is_int_value = np.all(gene_corr_reference.X.data.astype(int)[:1000] == gene_corr_reference.X.data[:1000])
         assert is_int_dtype or not is_int_value, "adata_reference.X should contain raw counts, but appears to be normalized. Please provide raw counts for gene_corr_reference.X."      
 
         # assert that all genes in the data are in the reference too.

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -204,7 +204,7 @@ def setup_anndata(
         assert is_int_dtype or not is_int_value, "adata_reference.X should contain raw counts, but appears to be normalized. Please provide raw counts for gene_corr_reference.X."      
 
         # assert that all genes in the data are in the reference too.
-        genes_not_in_reference = set(ad.var.index) - set(gene_corr_reference.var.index)
+        genes_not_in_reference = list(set(ad.var.index) - set(gene_corr_reference.var.index))
         if len(genes_not_in_reference) > 0:
             msg = f"WARNING: {len(genes_not_in_reference)} genes are in the data, but not in the provided gene correlation reference."
             for gene in genes_not_in_reference[:5]: # print up to 5 missing genes
@@ -221,7 +221,7 @@ def setup_anndata(
         assert len(failing_genes) == 0, (f"{len(failing_genes)} genes in the gene_corr_reference fail the genes_min_counts threshold, including: {', '.join(failing_genes.index[:5])} and {len(failing_genes) - 5} more.")
 
         # subset and put reference genes in same order as sample genes
-        ref = gene_corr_reference[:, ad.var.index]
+        ref = gene_corr_reference[:, ad.var.index].copy()
 
         # normalise
         ref = _normalise(ref)


### PR DESCRIPTION
Revised the gene correlation reference feature so that we check to see if it contains raw counts, and then normalize counts the same way segger does. Also, added an assertion to make sure that all genes in the reference anndata pass the genes min counts threshold set by segger. Example use case: if you have multiple samples you want to segment but want to use the same gene-gene correlation prior, pool the desired samples together into one anndata, ensuring that the anndata contains raw counts, all genes pass the min counts threshold, and that the anndata contains all genes present in the samples you want to segment. 

New parameters:
- `gene_corr_reference_path` (`--gene-corr-reference-path`): Path to an `.h5ad` reference dataset. Used to compute gene-gene PCA embeddings. `.X` must be raw counts.
- `gene_missing_strategy` (`--gene-missing-strategy`): What to do when genes in the data are missing in the reference. Defaults to "error". Alternative use "remove" to remove these from the data. Work in progress is "fill" which will use correlations from the data for missing genes only.