### PR TITLE
[integration/peerlab] Bugfix: Warn instead of Fail when margins are too large

### DIFF
--- a/src/segger/data/tiling.py
+++ b/src/segger/data/tiling.py
@@ -101,11 +101,15 @@ class Tiling(ABC):
                 mitre_limit=margin / 2,
             )
             missing = buffered.is_empty.sum()
+            # handling tiles too small for buffer
             if missing != 0:
-                raise ValueError(
+                import warnings
+                warnings.warn(
                     f"Margin ({margin}) is too large, causing {missing} "
-                    f"tile(s) to disappear. Consider using a smaller margin."
+                    f"tile(s) to disappear. These tiles will be removed from the query."
                 )
+                # Filter out the empty tiles
+                buffered = buffered[~buffered.is_empty]
             tiles = buffered
 
         # Spatial query


### PR DESCRIPTION
Closes #2 

If margins are too large, segger currently fails instead of removing empty tiles. Future fix should include adaptive tiling parameters, this should do for now though. Thanks @srose89 