### PR TITLE
[integration/peerlab] Optimisation/quadtree memory optimisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ __marimo__/
 .dev
 .dev/*
 *.pyc
+*memray*

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -1,6 +1,7 @@
+import os
 import rmm
-rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
-
-from rmm.allocators.cupy import rmm_cupy_allocator
 import cupy as cp
+import rmm.allocators.cupy as rmm_cupy_allocator
+
+rmm.reinitialize(pool_allocator=True, managed_memory=True)
 cp.cuda.set_allocator(rmm_cupy_allocator)

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -17,16 +17,13 @@ def _get_pool_size():
         mr = mr.get_upstream()
     return mr.pool_size()
 
-def print_free_mem():
+def free_mem_str() -> str:
     stats = get_statistics()
     pool_size = _get_pool_size()
     _, total = cp.cuda.Device().mem_info
-
     in_use = stats.current_bytes
-    pool_free = pool_size - in_use         # room left in the pool
-    headroom = total - pool_size           # room left on device for pool growth
-
-    print(
+    pool_free = pool_size - in_use
+    return (
         f"In use: {in_use / 1e9:.1f} GB | "
         f"Pool free: {pool_free / 1e9:.1f} GB | "
         f"Pool: {pool_size / 1e9:.1f} GB | "
@@ -34,3 +31,6 @@ def print_free_mem():
         f"Peak: {stats.peak_bytes / 1e9:.1f} GB | "
         f"Count: {stats.current_count}"
     )
+
+def print_free_mem():
+    print(free_mem_str())

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -1,35 +1,25 @@
-import os
 from pathlib import Path
 import cupy as cp
+import torch
 import rmm
 from rmm.allocators.cupy import rmm_cupy_allocator
+from rmm.allocators.torch import rmm_torch_allocator
 from rmm.statistics import enable_statistics, get_statistics
 
+# Single RMM pool shared by CuPy/cuDF/cuSpatial AND PyTorch. Must be set before
+# any CUDA tensor is created.
 rmm.reinitialize(pool_allocator=True, managed_memory=True)
 cp.cuda.set_allocator(rmm_cupy_allocator)
+torch.cuda.memory.change_current_allocator(rmm_torch_allocator)
 enable_statistics()
-
-INPUT_DIR = Path('../data/inputs/WTA_Preview_FFPE_Breast_Cancer')
-
-def _get_pool_size():
-    mr = rmm.mr.get_current_device_resource()
-    while not isinstance(mr, rmm.mr.PoolMemoryResource):
-        mr = mr.get_upstream()
-    return mr.pool_size()
 
 def free_mem_str() -> str:
     stats = get_statistics()
-    pool_size = _get_pool_size()
-    free, total = cp.cuda.Device().mem_info
-    in_use = stats.current_bytes
-    pool_free = pool_size - in_use
-    gpu_used = total - free
     return (
-        f"GPU used: {gpu_used / 1e9:.1f} GB | "
-        f"Pool free: {pool_free / 1e9:.1f} GB | "
-        f"Peak: {stats.peak_bytes / 1e9:.1f} GB | "
-        f"Count: {stats.current_count}"
+        f"GPU: {stats.current_bytes / 1e9:.2f} GB "
+        f"(peak {stats.peak_bytes / 1e9:.2f} GB)"
     )
+
 
 def print_free_mem():
     print(free_mem_str())

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -20,14 +20,13 @@ def _get_pool_size():
 def free_mem_str() -> str:
     stats = get_statistics()
     pool_size = _get_pool_size()
-    _, total = cp.cuda.Device().mem_info
+    free, total = cp.cuda.Device().mem_info
     in_use = stats.current_bytes
     pool_free = pool_size - in_use
+    gpu_used = total - free
     return (
-        f"In use: {in_use / 1e9:.1f} GB | "
+        f"GPU used: {gpu_used / 1e9:.1f} GB | "
         f"Pool free: {pool_free / 1e9:.1f} GB | "
-        f"Pool: {pool_size / 1e9:.1f} GB | "
-        f"Total: {total / 1e9:.1f} GB | "
         f"Peak: {stats.peak_bytes / 1e9:.1f} GB | "
         f"Count: {stats.current_count}"
     )

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -1,0 +1,6 @@
+import rmm
+rmm.reinitialize(pool_allocator=True, initial_pool_size="16GB")
+
+from rmm.allocators.cupy import rmm_cupy_allocator
+import cupy as cp
+cp.cuda.set_allocator(rmm_cupy_allocator)

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -1,5 +1,5 @@
 import rmm
-rmm.reinitialize(pool_allocator=True, initial_pool_size="16GB")
+rmm.mr.set_current_device_resource(rmm.mr.CudaAsyncMemoryResource())
 
 from rmm.allocators.cupy import rmm_cupy_allocator
 import cupy as cp

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -1,7 +1,36 @@
 import os
-import rmm
+from pathlib import Path
 import cupy as cp
-import rmm.allocators.cupy as rmm_cupy_allocator
+import rmm
+from rmm.allocators.cupy import rmm_cupy_allocator
+from rmm.statistics import enable_statistics, get_statistics
 
 rmm.reinitialize(pool_allocator=True, managed_memory=True)
 cp.cuda.set_allocator(rmm_cupy_allocator)
+enable_statistics()
+
+INPUT_DIR = Path('../data/inputs/WTA_Preview_FFPE_Breast_Cancer')
+
+def _get_pool_size():
+    mr = rmm.mr.get_current_device_resource()
+    while not isinstance(mr, rmm.mr.PoolMemoryResource):
+        mr = mr.get_upstream()
+    return mr.pool_size()
+
+def print_free_mem():
+    stats = get_statistics()
+    pool_size = _get_pool_size()
+    _, total = cp.cuda.Device().mem_info
+
+    in_use = stats.current_bytes
+    pool_free = pool_size - in_use         # room left in the pool
+    headroom = total - pool_size           # room left on device for pool growth
+
+    print(
+        f"In use: {in_use / 1e9:.1f} GB | "
+        f"Pool free: {pool_free / 1e9:.1f} GB | "
+        f"Pool: {pool_size / 1e9:.1f} GB | "
+        f"Total: {total / 1e9:.1f} GB | "
+        f"Peak: {stats.peak_bytes / 1e9:.1f} GB | "
+        f"Count: {stats.current_count}"
+    )

--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -167,7 +167,7 @@ def segment(
         group=group_prediction,
     )] = registry.get_default("prediction_graph_max_k"),
 
-    prediction_expansion_ratio: Annotated[float | None, registry.get_parameter(
+    prediction_graph_buffer_ratio: Annotated[float | None, registry.get_parameter(
         "prediction_graph_buffer_ratio",
         validator=validators.Number(gt=0),
         group=group_prediction,
@@ -337,7 +337,7 @@ def segment(
         transcripts_graph_max_dist=transcripts_max_dist,
         prediction_graph_mode=prediction_mode,
         prediction_graph_max_k=prediction_max_k,
-        prediction_graph_buffer_ratio=prediction_expansion_ratio,
+        prediction_graph_buffer_ratio=prediction_graph_buffer_ratio,
         tiling_margin_training=tiling_margin_training,
         tiling_margin_prediction=tiling_margin_prediction,
         tiling_nodes_per_tile=max_nodes_per_tile,

--- a/src/segger/data/partition/dataset.py
+++ b/src/segger/data/partition/dataset.py
@@ -384,10 +384,17 @@ class PartitionDataset(torch.utils.data.Dataset):
         permutation = torch.argsort(labels)
 
         # Pointers to splits between partitions
-        sizes = torch.bincount(
-            labels[permutation],
-            minlength=self._num_partitions,
-        )
+        try:
+            sizes = torch.bincount(
+                labels[permutation],
+                minlength=self._num_partitions,
+            )
+        # catch: RuntimeError: bincount only supports 1-d non-negative integral inputs
+        except RuntimeError as e:
+            labels_sub = labels[permutation][:10]
+            raise RuntimeError(
+                f"N Labels: {len(labels)}, Sample labels: {labels_sub}, Min label: {labels_sub.min()}, Max label: {labels_sub.max()}. Original error message: {str(e)}"
+            ) from e
         indptr = torch.cat((
             torch.tensor([0], device=labels.device),
             torch.cumsum(sizes, dim=0)

--- a/src/segger/data/tiling.py
+++ b/src/segger/data/tiling.py
@@ -203,7 +203,7 @@ class QuadTreeTiling(Tiling):
     ):
         # Calculate QuadTree on points and set as tiles
         points = points_to_geoseries(positions, backend='cuspatial')
-        _, quadtree = get_quadtree_index(
+        _, quadtree, _ = get_quadtree_index(
             points,
             max_tile_size,
             with_bounds=True,

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -247,13 +247,7 @@ def setup_anndata(
     C = np.nan_to_num(C, 0, posinf=True, neginf=True)
     model = sklearn.decomposition.PCA(n_components=cells_embedding_size, random_state=0)
     ad.varm['X_corr'] = model.fit_transform(C)
-    #---------------------------------------------------------------------------------
-
-    # Build gene embedding on filtered dataset
-    #C = np.corrcoef(ad[ad.obs['filtered']].layers['norm'].todense().T)
-    #C = np.nan_to_num(C, 0, posinf=True, neginf=True)
-    #model = sklearn.decomposition.PCA(n_components=cells_embedding_size)
-    #ad.varm['X_corr'] = model.fit_transform(C)
+    del C, model
 
     # Build PCs on filtered cells and project all cells
     counts_sparse_gpu = cupyx.scipy.sparse.csr_matrix(ad.layers['norm'])

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -260,6 +260,7 @@ def setup_anndata(
     model = cuml.PCA(n_components=cells_embedding_size, random_state=0)
     model.fit(counts_sparse_gpu[ad.obs['filtered'].values])
     ad.obsm['X_pca'] = model.transform(counts_sparse_gpu).get()
+    del counts_sparse_gpu, model
 
     # Compute clusters on filtered cells
     cell_clusters = phenograph_rapids(

--- a/src/segger/data/utils/heterodata.py
+++ b/src/segger/data/utils/heterodata.py
@@ -3,7 +3,7 @@ from typing import Literal
 import geopandas as gpd
 import polars as pl
 import scanpy as sc
-import numpy as np
+import logging
 import torch
 
 from ...io import TrainingBoundaryFields, TrainingTranscriptFields
@@ -13,6 +13,7 @@ from .neighbors import (
     setup_prediction_graph,
 )
 
+logger = logging.getLogger(__name__)
 
 def setup_heterodata(
     transcripts: pl.DataFrame,
@@ -45,7 +46,7 @@ def setup_heterodata(
         tx_fields.gene_cluster,
     ]
     # Update transcripts with fields for training
-    
+    logger.debug(f"Setting up HeteroData with {len(transcripts)} transcripts and {len(boundaries)} boundaries")
     transcripts = (
         transcripts
         # Reset columns
@@ -113,6 +114,7 @@ def setup_heterodata(
     data = HeteroData()
 
     # Transcript nodes
+    logger.debug("Setting up transcript nodes")
     data['tx']['x'] = transcripts[tx_fields.gene_encoding].to_torch()
     data['tx']['cluster'] = transcripts[tx_fields.gene_cluster].to_torch()
     data['tx']['index'] = transcripts[tx_fields.row_index].to_torch()
@@ -120,6 +122,7 @@ def setup_heterodata(
     data['tx']['pos'] = data['tx']['geometry']
 
     # Boundary nodes
+    logger.debug("Setting up boundary nodes")
     data['bd']['x'] = torch.tensor(
         adata.obsm[cells_embedding_key]).to(torch.float)
     data['bd']['cluster'] = torch.tensor(
@@ -131,6 +134,7 @@ def setup_heterodata(
     data['bd']['pos'] = data['bd']['geometry']
 
     # Transcript neighbors graph
+    logger.debug("Setting up transcript neighbors graph")
     data['tx', 'neighbors', 'tx'].edge_index = setup_transcripts_graph(
         transcripts,
         max_k=transcripts_graph_max_k,
@@ -138,12 +142,14 @@ def setup_heterodata(
     )
 
     # Reference segmentation graph
+    logger.debug("Setting up segmentation graph")
     data['tx', 'belongs', 'bd'].edge_index = setup_segmentation_graph(
         transcripts,
         segmentation_mask=segmentation_mask,
     )
 
     # Transcript-cell graph for prediction
+    logger.debug("Setting up prediction graph")
     data['tx', 'neighbors', 'bd'].edge_index = setup_prediction_graph(
         transcripts,
         boundaries,

--- a/src/segger/data/utils/neighbors.py
+++ b/src/segger/data/utils/neighbors.py
@@ -119,33 +119,6 @@ def edge_index_to_knn(
     return neighbor_table
 
 
-def kdtree_neighbors_deprecate(
-    points: np.ndarray,
-    max_k: int,
-    max_dist: float,
-    query: np.ndarray | None = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Wrapper for KDTree kNN and conversion to edge_index COO format.
-    TODO: Add description.
-    """
-    tree = KDTree(points, leafsize=100)
-    _, indices = tree.query(
-        points if query is None else query,
-        k=max_k,
-        distance_upper_bound=max_dist,
-        workers=-1,
-    )
-    del tree
-    
-    indices = torch.from_numpy(indices)
-    gc.collect()  # make sure numpy copy is gone before conversion
-    edge_index, index_pointer = knn_to_edge_index(indices)
-    del indices   # remove big indices tensor
-    gc.collect()
-    
-    return edge_index, index_pointer
-
-
 def kdtree_neighbors(
     points: np.ndarray,
     max_k: int,

--- a/src/segger/data/utils/neighbors.py
+++ b/src/segger/data/utils/neighbors.py
@@ -135,6 +135,8 @@ def kdtree_neighbors(
         distance_upper_bound=max_dist,
         workers=-1,
     )
+    del tree
+    
     indices = torch.from_numpy(indices)
     gc.collect()  # make sure numpy copy is gone before conversion
     edge_index, index_pointer = knn_to_edge_index(indices)

--- a/src/segger/data/utils/neighbors.py
+++ b/src/segger/data/utils/neighbors.py
@@ -212,7 +212,7 @@ def setup_prediction_graph(
         points=points,
         polygons=polygons,
         predicate='contains',
-        batches=10,
+        batches=100,
     )
 
     return torch.tensor(

--- a/src/segger/data/utils/neighbors.py
+++ b/src/segger/data/utils/neighbors.py
@@ -119,7 +119,7 @@ def edge_index_to_knn(
     return neighbor_table
 
 
-def kdtree_neighbors(
+def kdtree_neighbors_deprecate(
     points: np.ndarray,
     max_k: int,
     max_dist: float,
@@ -144,6 +144,50 @@ def kdtree_neighbors(
     gc.collect()
     
     return edge_index, index_pointer
+
+
+def kdtree_neighbors(
+    points: np.ndarray,
+    max_k: int,
+    max_dist: float,
+    chunk_size: int = 2_000_000,
+    query: np.ndarray | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Wrapper for KDTree kNN and conversion to edge_index COO format.
+    TODO: Add description.
+    """
+
+    # init
+    max_memory = 0
+    q = points if query is None else query
+    N = q.shape[0]
+
+    # build tree
+    tree = KDTree(points, leafsize=100)
+
+    # TODO: Remove index pointer - is unused
+    edge_indices = []
+    for i in range(0, N, chunk_size):
+        # get neighbors
+        _, indices = tree.query(
+            q[i:i+chunk_size],
+            k=max_k,
+            distance_upper_bound=max_dist,
+            workers=-1,
+        )
+        indices = torch.from_numpy(indices.copy()) # copy release numpy arra
+
+        # get edges
+        edge_index, _ = knn_to_edge_index(indices, padding_value=N) # [0] is row-idx of source, [1] is col-idx of destination
+        edge_index[0] += i # shift row-idx by chunk offset
+        edge_indices.append(edge_index)
+
+    del indices, edge_index # remove big tensors before concatenation
+    del tree # 9GB for 600M transcripts
+    gc.collect()
+
+    edge_indices = torch.cat(edge_indices, dim=1)
+    return edge_indices, None
 
 
 def setup_transcripts_graph(

--- a/src/segger/data/writer.py
+++ b/src/segger/data/writer.py
@@ -13,9 +13,12 @@ from ..io import TrainingTranscriptFields, TrainingBoundaryFields
 from . import ISTDataModule
 from .utils.anndata import anndata_from_transcripts
 
+logger = logging.getLogger(__name__)
+
+
 class ISTSegmentationWriter(BasePredictionWriter):
     """TODO: Description
-    
+
     Parameters
     ----------
     output_directory : Path
@@ -31,14 +34,12 @@ class ISTSegmentationWriter(BasePredictionWriter):
         super().__init__(write_interval="epoch")
         self.output_directory = Path(output_directory)
         self.save_anndata = save_anndata
-        self.segger_logger = logging.getLogger(__name__)
 
         # setup debugging
         self.debug = debug
         self.path_debug = None
         self.n_tx_predicted = 0
         if debug:
-            logging.getLogger("segger").setLevel("DEBUG")
             self.path_debug = output_directory / "debug"
             self.path_debug.mkdir(exist_ok=True, parents=True)
 
@@ -64,21 +65,21 @@ class ISTSegmentationWriter(BasePredictionWriter):
         # write predictions as pickle
         if self.debug:
             import pickle
-            self.segger_logger.debug(f"Saving predictions to {self.path_debug / 'predictions.pkl'}")
+            logger.debug(f"Saving predictions to {self.path_debug / 'predictions.pkl'}")
             with open(self.path_debug / "predictions.pkl", "wb") as f:
                 pickle.dump(predictions, f)
 
         # segment transcripts
-        self.segger_logger.debug("Assigning transcripts to cells...")
+        logger.debug("Assigning transcripts to cells...")
         obs = trainer.datamodule.ad.obs
-        segmentation = self.assign_transcripts_to_cells(obs, predictions, logger=self.segger_logger)
+        segmentation = self.assign_transcripts_to_cells(obs, predictions, logger=logger)
 
         # write transcripts
-        self.segger_logger.debug(f"Writing segmentation output to {self.output_directory}...")
+        logger.debug(f"Writing segmentation output to {self.output_directory}...")
         segmentation.write_parquet(self.output_directory / 'segger_segmentation.parquet')
 
         # write anndata
-        self.segger_logger.debug("Writing AnnData output...")
+        logger.debug("Writing AnnData output...")
         if self.save_anndata:
             self.write_anndata(trainer, segmentation)
 
@@ -269,20 +270,20 @@ class ISTSegmentationWriter(BasePredictionWriter):
             return
         log_every = 50
         if batch_idx % log_every == 0:
-            self.segger_logger.info(
+            logger.info(
                 f"Finished prediction batch '{batch_idx}'. # TX so far {self.n_tx_predicted / 1e6:.1f}M"
             )
     
     def on_fit_start(self, trainer, pl_module):
         if not self.debug:
             return
-        self.segger_logger.debug(f"Saving adata to {self.path_debug / 'adata_debug.h5ad'}")
+        logger.debug(f"Saving adata to {self.path_debug / 'adata_debug.h5ad'}")
         trainer.datamodule.ad.write_h5ad(self.path_debug / "adata_debug.h5ad")
 
     def on_fit_end(self, trainer, pl_module):
         if not self.debug:
             return
         if self.debug:
-            self.segger_logger.debug(f"Saving trainer state to {self.path_debug / 'trainer_state_final.ckpt'}")
+            logger.debug(f"Saving trainer state to {self.path_debug / 'trainer_state_final.ckpt'}")
             trainer.save_checkpoint(self.path_debug / "trainer_state_final.ckpt")
 

--- a/src/segger/geometry/conversion.py
+++ b/src/segger/geometry/conversion.py
@@ -143,7 +143,7 @@ def points_to_geoseries(
         if isinstance(data, cuspatial.GeoSeries):
             points.index = pd.Index(data.index.to_numpy())
     else:  # cuspatial
-        coords = cp.asarray(coords).ravel().astype('double')
+        coords = cp.asarray(coords, dtype=cp.float64).ravel()
         points = cuspatial.GeoSeries.from_points_xy(coords)
         if isinstance(data, gpd.GeoSeries):
             points.index = cudf.Index(data.index)
@@ -290,7 +290,7 @@ def polygons_to_geoseries(
         if isinstance(data, cuspatial.GeoSeries):
             polygons.index = pd.Index(data.index.to_numpy())
     else:  # cuspatial
-        vertices = cp.asarray(vertices).ravel().astype('double')
+        vertices = cp.asarray(vertices, dtype=cp.float64).ravel()
         ring_offsets = cp.asarray(ring_offsets)
         part_offsets = cp.arange(len(ring_offsets), dtype='int32')
         polygons = cuspatial.GeoSeries.from_polygons_xy(

--- a/src/segger/geometry/quadtree.py
+++ b/src/segger/geometry/quadtree.py
@@ -25,13 +25,14 @@ def get_quadtree_kwargs(
         A dictionary of keyword arguments including x_min, x_max, y_min,
         y_max, scale, and max_depth.
     """
-    # Calculate bounds
-    x_min = float(points.points.x.min())
-    x_max = float(points.points.x.max())
-    y_min = float(points.points.y.min())
-    y_max = float(points.points.y.max())
+    # Calculate bounds | Optimisation: Use interleaved view, without copying data
+    xy = cp.asarray(points.points.xy).reshape(-1, 2)  # zero-copy view                                                                                                                                                                                                                                                                                                                                                                                 
+    x_min = float(xy[:, 0].min())
+    x_max = float(xy[:, 0].max())                                                                                                                                                                                                                                                                                                                                                                                                                      
+    y_min = float(xy[:, 1].min())
+    y_max = float(xy[:, 1].max())       
 
-    # Get hyperparams for quadtree
+   # Get hyperparams for quadtree
     extent = max(x_max - x_min, y_max - y_min)
     max_depth = 1
     while extent // (1 << max_depth) > 0:
@@ -140,7 +141,7 @@ def get_quadtree_index(
     points: cuspatial.GeoSeries,
     max_size: int,
     with_bounds: bool = True,
-) -> tuple[cudf.Series, cudf.DataFrame]:
+) -> tuple[cudf.Series, cudf.DataFrame, dict]:
     """Build a cuSpatial quadtree from 2D point data.
 
     Parameters
@@ -190,7 +191,7 @@ def get_quadtree_index(
             y_max=y_max,
         )
 
-    return indices, quadtree
+    return indices, quadtree, kwargs
 
 
 def quadtree_to_geoseries(

--- a/src/segger/geometry/query.py
+++ b/src/segger/geometry/query.py
@@ -3,6 +3,7 @@ import geopandas as gpd
 import numpy as np
 import cuspatial
 import cudf
+import cupy as cp
 
 from .conversion import (
     polygons_to_geoseries,
@@ -47,14 +48,15 @@ def _points_in_polygons_contains(
         mapping each contained point to its containing polygon.
     """
     # Setup inputs for spatial join
+    cp.get_default_memory_pool().free_all_blocks()
+    cp.get_default_pinned_memory_pool().free_all_blocks()
     if max_size is None:
         max_size = 10000 if len(points) > 5e7 else 1000  # heuristic
-    point_indices, quadtree = get_quadtree_index(
+    point_indices, quadtree, kwargs = get_quadtree_index(
         points,
         max_size,
         with_bounds=False
     )
-    kwargs = get_quadtree_kwargs(points)
 
     # Perform spatial join in batches
     batch_idx = np.linspace(0, len(polygons), (batches or 1) + 1, dtype=int)

--- a/src/segger/geometry/query.py
+++ b/src/segger/geometry/query.py
@@ -48,8 +48,6 @@ def _points_in_polygons_contains(
         mapping each contained point to its containing polygon.
     """
     # Setup inputs for spatial join
-    cp.get_default_memory_pool().free_all_blocks()
-    cp.get_default_pinned_memory_pool().free_all_blocks()
     if max_size is None:
         max_size = 10000 if len(points) > 5e7 else 1000  # heuristic
     point_indices, quadtree, kwargs = get_quadtree_index(

--- a/src/segger/io/preprocessor.py
+++ b/src/segger/io/preprocessor.py
@@ -10,7 +10,6 @@ import pandas as pd
 import json
 import warnings
 import logging
-import sys
 
 from .cosmx import get_cosmx_polygons
 from .utils import (
@@ -32,6 +31,8 @@ from .fields import (
 
 # Ignore pandas warnings in CosMX transcripts file
 warnings.filterwarnings("ignore", category=DtypeWarning)
+
+logger = logging.getLogger(__name__)
 
 # Register of available ISTPreprocessor subclasses keyed by platform name.
 PREPROCESSORS = {}
@@ -137,7 +138,8 @@ class ISTPreprocessor(ABC):
         verbose : bool
             Whether to display logging messages
         """
-        logger = self._setup_logging(verbose)
+        if verbose:
+            logging.getLogger("segger").setLevel("INFO")
 
         self.tx_out = out_dir / 'transcripts.parquet'
         self.ad_out = out_dir / 'nucleus_boundaries.h5ad'
@@ -221,34 +223,6 @@ class ISTPreprocessor(ABC):
         
         return joined.rename(columns={"index_right": boundary_label})
     
-    def _setup_logging(self, verbose: bool = False) -> logging.Logger:
-        class TimeFilter(logging.Filter):
-            
-            def filter(self, record):
-                from datetime import datetime
-                try:
-                    last = self.last
-                except AttributeError:
-                    last = record.relativeCreated
-                delta = datetime.fromtimestamp(record.relativeCreated/1e3) - \
-                        datetime.fromtimestamp(last/1e3)
-                record.relative = '{0:.2f}'.format(
-                    delta.seconds + delta.microseconds/1e6)
-                self.last = record.relativeCreated
-                return True
-
-        logger = logging.getLogger()
-        logger.setLevel(logging.INFO if verbose else logging.WARNING)
-
-        if not logger.handlers:
-            handler = logging.StreamHandler(sys.stdout)
-            logger.addHandler(handler)
-        for hndl in logger.handlers:
-            hndl.addFilter(TimeFilter())
-            hndl.setFormatter(logging.Formatter(
-                fmt="%(asctime)s (%(relative)ss) %(message)s"
-            ))
-        return logger
 
 
 @register_preprocessor("nanostring_cosmx")

--- a/src/segger/models/ist_encoder.py
+++ b/src/segger/models/ist_encoder.py
@@ -315,11 +315,6 @@ class ISTEncoder(torch.nn.Module):
 
         x_dict = {k: F.gelu(x) for k, x in x_dict.items()}
 
-        # Add positional embedding
-
-        # GeLu for some reason
-        x_dict = {k: F.gelu(x) for k, x in x_dict.items()}
-
         # Graph convolutions with GATv2
         for conv_layer in self.conv_layers:
             x_dict = conv_layer(x_dict, edge_index_dict)

--- a/src/segger/models/lightning_model.py
+++ b/src/segger/models/lightning_model.py
@@ -294,7 +294,8 @@ class LitISTEncoder(LightningModule):
         gen_idx = batch['tx']['x']
         mask = batch['tx']['predict_mask']
 
-        return src_idx[mask], seg_idx[mask], max_sim[mask], gen_idx[mask]
+        # To cpu, else gpu is held until end of predict loop
+        return src_idx[mask].cpu(), seg_idx[mask].cpu(), max_sim[mask].cpu(), gen_idx[mask].cpu()
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
         """Configures the optimizer for training."""

--- a/src/segger/utils.py
+++ b/src/segger/utils.py
@@ -2,13 +2,27 @@ import logging
 import os
 import sys
 
+
+class MemFilter(logging.Filter):
+    def filter(self, record):
+        try:
+            from segger import free_mem_str
+            record.mem = f" | {free_mem_str()}"
+        except Exception:
+            record.mem = ""
+        return True
+
+
 def setup_logging(level: str = "WARNING", log_file: str = None):
-    fmt = "%(asctime)s | %(levelname)-8s | %(name)s:%(lineno)d - %(message)s"
+    fmt = "%(asctime)s | %(levelname)-8s | %(name)s:%(lineno)d%(mem)s - %(message)s"
     datefmt = "%Y-%m-%d %H:%M:%S"
 
     handlers = [logging.StreamHandler(sys.stdout)]
     if log_file:
         handlers.append(logging.FileHandler(log_file))
+
+    for handler in handlers:
+        handler.addFilter(MemFilter())
 
     logging.basicConfig(
         level=getattr(logging, level.upper()),

--- a/src/segger/utils.py
+++ b/src/segger/utils.py
@@ -31,3 +31,7 @@ def setup_logging(level: str = "WARNING", log_file: str = None):
         handlers=handlers,
         force=True,  # override any previously set handlers
     )
+
+    segger_log_level = os.environ.get("SEGGER_LOG_LEVEL")
+    if segger_log_level:
+        logging.getLogger("segger").setLevel(segger_log_level.upper())


### PR DESCRIPTION
Closes #35 

Optimising memory constraints for Segger:

Memory Changes
- Reuse outputs from `get_quadtree_kwargs` (this crashed initially with 800GB memory)
- Use lazier access to `points.points.xy`
- Try freeing blocks at beginning of `_points_in_polygons_contains`
- Add batched logic for assigning indices (see comment)

Other
- Improved logging of memory when using `SEGGER_LOG_LEVEL=DEBUG`
- Added more `debug` level logging overall

**--> Segger can now be run on an A100 with 250GB memory on the public [Atera Breast Cancer](https://www.10xgenomics.com/datasets/atera-wta-ffpe-human-breast-cancer) Dataset.**