### PR TITLE
[integration/peerlab] Bugfix/tiling issue

### DIFF
--- a/src/segger/geometry/quadtree.py
+++ b/src/segger/geometry/quadtree.py
@@ -1,3 +1,5 @@
+import logging
+
 from shapely import from_ragged_array, GeometryType
 from typing import Literal
 import geopandas as gpd
@@ -7,10 +9,13 @@ import numpy as np
 import cupy as cp
 import cuspatial
 import cudf
+import logging
 
+logger = logging.getLogger(__name__)
 
 def get_quadtree_kwargs(
     points: cuspatial.GeoSeries,
+    margin_bounds: float = 50,
 ) -> dict[str, float]:
     """Calculate keyword arguments for `cuspatial.quadtree_on_points`.
 
@@ -27,10 +32,10 @@ def get_quadtree_kwargs(
     """
     # Calculate bounds | Optimisation: Use interleaved view, without copying data
     xy = cp.asarray(points.points.xy).reshape(-1, 2)  # zero-copy view                                                                                                                                                                                                                                                                                                                                                                                 
-    x_min = float(xy[:, 0].min())
-    x_max = float(xy[:, 0].max())                                                                                                                                                                                                                                                                                                                                                                                                                      
-    y_min = float(xy[:, 1].min())
-    y_max = float(xy[:, 1].max())       
+    x_min = float(xy[:, 0].min()) - margin_bounds
+    x_max = float(xy[:, 0].max()) + margin_bounds
+    y_min = float(xy[:, 1].min()) - margin_bounds
+    y_max = float(xy[:, 1].max()) + margin_bounds
 
    # Get hyperparams for quadtree
     extent = max(x_max - x_min, y_max - y_min)
@@ -136,11 +141,11 @@ def get_quadrant_bounds(
     
     return quadtree
 
-
 def get_quadtree_index(
     points: cuspatial.GeoSeries,
     max_size: int,
     with_bounds: bool = True,
+    max_retries: int = 3,
 ) -> tuple[cudf.Series, cudf.DataFrame, dict]:
     """Build a cuSpatial quadtree from 2D point data.
 
@@ -151,8 +156,10 @@ def get_quadtree_index(
     max_size : int
         Maximum number of points allowed in a single tile.
     with_bounds : bool, optional
-        Whether to return the x, y bounds of each leaf with the quadtree 
+        Whether to return the x, y bounds of each leaf with the quadtree
         DataFrame. Default is True.
+    max_retries : int, optional
+        Retries on invalid tree, each growing ``max_size`` by 5%. Default 6.
 
     Returns
     -------
@@ -170,21 +177,33 @@ def get_quadtree_index(
     scale = kwargs['scale']
     max_depth = kwargs['max_depth']
 
-    # Calculate quadtree on region
-    indices, quadtree = cuspatial.quadtree_on_points(
-        points,
-        x_min=x_min,
-        x_max=x_max,
-        y_min=y_min,
-        y_max=y_max,
-        scale=scale,
-        max_depth=max_depth,
-        max_size=max_size,
-    )
+    # Calculate quadtree on region (retry on invalid tree, see issue #40)
+    for i in range(max_retries + 1):
+        indices, quadtree = cuspatial.quadtree_on_points(
+            points,
+            x_min=x_min,
+            x_max=x_max,
+            y_min=y_min,
+            y_max=y_max,
+            scale=scale,
+            max_depth=max_depth,
+            max_size=max_size,
+        )
+
+        # check if valid (see segger issue #40)
+        if is_quadtree_valid(quadtree, len(points)):
+            break
+        logger.warning(f"Invalid quadtree generated with max_size={max_size}. Retrying with increased max_size.")
+    else:
+        raise RuntimeError(
+            f"cuSpatial returned an invalid quadtree after {max_retries + 1} "
+            f"attempts (see segger issue #40)."
+        )
+
     # Add bounds of tiles
     if with_bounds:
         quadtree = get_quadrant_bounds(
-            quadtree, 
+            quadtree,
             x_min=x_min,
             x_max=x_max,
             y_min=y_min,
@@ -235,3 +254,14 @@ def quadtree_to_geoseries(
             (ring_offset.get(), part_offset.get()),
         )
         return gpd.GeoSeries(geometry)
+
+def is_quadtree_valid(quadtree: cudf.DataFrame, n_points: int) -> bool:
+    """
+    Checks that the leaves index every input point exactly once. cuSpatial
+    sometimes generates overlapping leaves that double-count points, which
+    causes missing tiles and `-1` labels downstream, as well as other unexpected behavior
+    (see segger issue #40).
+    """
+    leaves = quadtree[~quadtree['is_internal_node']]
+    points_tree = leaves["length"].sum()
+    return points_tree == n_points

--- a/src/segger/geometry/quadtree.py
+++ b/src/segger/geometry/quadtree.py
@@ -1,5 +1,3 @@
-import logging
-
 from shapely import from_ragged_array, GeometryType
 from typing import Literal
 import geopandas as gpd
@@ -177,6 +175,8 @@ def get_quadtree_index(
     scale = kwargs['scale']
     max_depth = kwargs['max_depth']
 
+    logger.debug(f"Building quadtree on {len(points)} points with max_size={max_size}, max_depth={max_depth}")
+
     # Calculate quadtree on region (retry on invalid tree, see issue #40)
     for i in range(max_retries + 1):
         indices, quadtree = cuspatial.quadtree_on_points(
@@ -200,6 +200,8 @@ def get_quadtree_index(
             f"cuSpatial returned an invalid quadtree after {max_retries + 1} "
             f"attempts (see segger issue #40)."
         )
+
+    logger.debug(f"Quadtree built: {int((~quadtree['is_internal_node']).sum())} leaves")
 
     # Add bounds of tiles
     if with_bounds:

--- a/src/segger/geometry/quadtree.py
+++ b/src/segger/geometry/quadtree.py
@@ -145,7 +145,7 @@ def get_quadtree_index(
     points: cuspatial.GeoSeries,
     max_size: int,
     with_bounds: bool = True,
-    max_retries: int = 3,
+    max_retries: int = 5,
 ) -> tuple[cudf.Series, cudf.DataFrame, dict]:
     """Build a cuSpatial quadtree from 2D point data.
 
@@ -193,7 +193,8 @@ def get_quadtree_index(
         # check if valid (see segger issue #40)
         if is_quadtree_valid(quadtree, len(points)):
             break
-        logger.warning(f"Invalid quadtree generated with max_size={max_size}. Retrying with increased max_size.")
+        logger.warning(f"Invalid quadtree generated with max_size={max_size}. Retry with max_size={max_size * 2}.")
+        max_size += 10000
     else:
         raise RuntimeError(
             f"cuSpatial returned an invalid quadtree after {max_retries + 1} "

--- a/src/segger/geometry/query.py
+++ b/src/segger/geometry/query.py
@@ -4,6 +4,7 @@ import numpy as np
 import cuspatial
 import cudf
 import cupy as cp
+import logging
 
 from .conversion import (
     polygons_to_geoseries,
@@ -13,6 +14,8 @@ from .quadtree import (
     get_quadtree_index,
     get_quadtree_kwargs,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _points_in_polygons_contains(
@@ -220,6 +223,8 @@ def points_in_polygons(
             f"Unsupported predicate '{predicate}'. Supported predicates are "
             f"'contains' and 'intersects'."
         )
+    logger.debug(f"points_in_polygons: {len(points)} points, {len(polygons)} polygons, predicate='{predicate}'")
+
     # Convert geometries to GeoSeries on GPU
     points = points_to_geoseries(points, backend='cuspatial')
     polygons = polygons_to_geoseries(polygons, backend='cuspatial')

--- a/src/segger/models/ist_encoder.py
+++ b/src/segger/models/ist_encoder.py
@@ -13,6 +13,9 @@ from torch.nn import (
 )
 import torch
 import math
+import logging
+
+logger = logging.getLogger(__name__)
 
 # --- Test positional encoding ---
 
@@ -281,6 +284,7 @@ class ISTEncoder(torch.nn.Module):
             out_channels,
             types=("tx", "bd")
         )
+        logger.debug(f"ISTEncoder: n_genes={n_genes}, in={in_channels}, hidden={hidden_channels}, out={out_channels}, layers={n_mid_layers + 2}")
 
     def forward(
         self,
@@ -304,6 +308,8 @@ class ISTEncoder(torch.nn.Module):
         Tensor
             Output node features after passing through the Segger model.
         """
+        logger.debug(f"ISTEncoder forward: tx={x_dict['tx'].shape}, bd={x_dict['bd'].shape}")
+
         # Linearly project embedding to input dim
         x_dict = {k: self.lin_first[k](x) for k, x in x_dict.items()}
 

--- a/src/segger/models/ist_encoder.py
+++ b/src/segger/models/ist_encoder.py
@@ -308,8 +308,6 @@ class ISTEncoder(torch.nn.Module):
         Tensor
             Output node features after passing through the Segger model.
         """
-        logger.debug(f"ISTEncoder forward: tx={x_dict['tx'].shape}, bd={x_dict['bd'].shape}")
-
         # Linearly project embedding to input dim
         x_dict = {k: self.lin_first[k](x) for k, x in x_dict.items()}
 


### PR DESCRIPTION
Closes #40. This PR makes building QuadTree constructino more robust. This issue is common across datasets, but particularly often seen when processing the [Atera Breast Cancer](https://www.10xgenomics.com/datasets/atera-wta-ffpe-human-breast-cancer) public dataset.

This PR fixes the error where `-1` is passed into `bincount`.

**Cause**: `cuspatial` sometimes generates invalid QuadTrees where tiles overlap across levels, while other regions are not covered at all. This results in invalid tile assignments during spatial queries. This issue appears randomly despite the pipeline being deterministic, and occurs in roughly 2–35% of Segger runs. In some datasets, such as Atera, even 100%.

Fix:
- Add `is_quadtree_valid`: Simple validation that all points are covered by the generated quadtree.
- Add `margin_bounds` to `get_quadtree_kwargs`: Expands the bounds used to construct the quadtree. This produces more valid trees.
- Retry quadtree construction with larger `max_size`: If a generated tree is invalid, rebuild with an increased tree size. Particularly important for `_points_in_polygons_contains` in `query.py`, which defaults to `max_size=10000`. In the Atera dataset this frequently produces invalid trees.

Example log of dynamically increasing tree size:
```
2026-05-17 23:08:45 | DEBUG    | segger.geometry.quadtree:178 | GPU: 20.61 GB (peak 67.49 GB) - Building quadtree on 624327019 points with max_size=10000, max_depth=14
2026-05-17 23:08:46 | WARNING  | segger.geometry.quadtree:196 | GPU: 23.11 GB (peak 67.49 GB) - Invalid quadtree generated with max_size=10000. Retry with max_size=20000.
2026-05-17 23:08:46 | DEBUG    | segger.geometry.quadtree:204 | GPU: 23.11 GB (peak 67.49 GB) - Quadtree built: 75131 leaves
```