### PR TITLE
Architecture-ablation flags: --aggregation mean, --no-tx-tx-edges

### DIFF
--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -150,6 +150,15 @@ def segment(
         group=group_transcripts_graph,
     )] = registry.get_default("transcripts_graph_max_dist"),
 
+    no_tx_tx_edges: Annotated[bool, Parameter(
+        help=(
+            "Ablation: remove transcript-transcript ('tx','neighbors','tx') "
+            "edges entirely, so transcripts receive no spatial-neighborhood "
+            "message passing. Defaults to keeping the edges."
+        ),
+        group=group_transcripts_graph,
+    )] = False,
+
 
     # Segmentation (Prediction) Graph
     prediction_mode: Annotated[
@@ -243,6 +252,18 @@ def segment(
         "normalize_embeddings",
         group=group_model,
     )] = registry.get_default("normalize_embeddings"),
+
+    aggregation: Annotated[
+        Literal["gatv2", "mean"],
+        Parameter(
+            help=(
+                "Message-passing aggregation. 'gatv2' (default) uses "
+                "attention; 'mean' ablates attention with mean aggregation "
+                "(SAGEConv, width matched to the attention heads)."
+            ),
+            group=group_model,
+        )
+    ] = "gatv2",
 
     # Loss
     segmentation_loss: Annotated[
@@ -347,6 +368,7 @@ def segment(
         genes_clusters_resolution=genes_clusters_resolution,
         transcripts_graph_max_k=transcripts_max_k,
         transcripts_graph_max_dist=transcripts_max_dist,
+        use_tx_tx_edges=not no_tx_tx_edges,
         prediction_graph_mode=prediction_mode,
         prediction_graph_max_k=prediction_max_k,
         prediction_graph_buffer_ratio=prediction_graph_buffer_ratio,
@@ -382,6 +404,7 @@ def segment(
         sg_weight_end=segmentation_loss_weight_end,
         normalize_embeddings=normalize_embeddings,
         use_positional_embeddings=use_positional_embeddings,
+        aggregation=aggregation,
     )
 
     # Setup Lightning Trainer

--- a/src/segger/data/data_module.py
+++ b/src/segger/data/data_module.py
@@ -144,6 +144,7 @@ class ISTDataModule(LightningDataModule):
     genes_clusters_resolution: float = 2.
     transcripts_graph_max_k: int = 5
     transcripts_graph_max_dist: float = 5.
+    use_tx_tx_edges: bool = True
     segmentation_graph_mode: Literal["nucleus", "cell"] = "nucleus"
     segmentation_graph_negative_edge_rate: float = 1.
     prediction_graph_mode: Literal["nucleus", "cell", "uniform"] = "cell"
@@ -234,6 +235,7 @@ class ISTDataModule(LightningDataModule):
             ),
             transcripts_graph_max_k=self.transcripts_graph_max_k,
             transcripts_graph_max_dist=self.transcripts_graph_max_dist,
+            use_tx_tx_edges=self.use_tx_tx_edges,
             prediction_graph_mode=self.prediction_graph_mode,
             prediction_graph_max_k=self.prediction_graph_max_k,
             prediction_graph_buffer_ratio=self.prediction_graph_buffer_ratio,

--- a/src/segger/data/utils/heterodata.py
+++ b/src/segger/data/utils/heterodata.py
@@ -25,6 +25,7 @@ def setup_heterodata(
     prediction_graph_mode: Literal["nucleus", "cell", "uniform"],
     prediction_graph_max_k: int,
     prediction_graph_buffer_ratio: float,
+    use_tx_tx_edges: bool = True,
     cells_embedding_key: str = 'X_pca',
     cells_clusters_column: str = 'phenograph_cluster',
     cells_encoding_column: str = 'cell_encoding',
@@ -134,13 +135,21 @@ def setup_heterodata(
     data['bd']['pos'] = data['bd']['geometry']
 
     # Transcript neighbors graph
-    logger.debug("Setting up transcript neighbors graph")
-    data['tx', 'neighbors', 'tx'].edge_index = setup_transcripts_graph(
-        transcripts,
-        max_k=transcripts_graph_max_k,
-        max_dist=transcripts_graph_max_dist,
-    )
-    logger.info(f"  tx-neighbors-tx edges: {data['tx', 'neighbors', 'tx'].edge_index.shape[1]:,}")
+    # Ablation: when use_tx_tx_edges is False, the ('tx','neighbors','tx')
+    # edge type is omitted entirely. HeteroConv iterates the edge types
+    # present in the data, so the model simply skips transcript-transcript
+    # message passing; transcript nodes are then updated only via the
+    # ('bd','contains','tx') edges.
+    if use_tx_tx_edges:
+        logger.debug("Setting up transcript neighbors graph")
+        data['tx', 'neighbors', 'tx'].edge_index = setup_transcripts_graph(
+            transcripts,
+            max_k=transcripts_graph_max_k,
+            max_dist=transcripts_graph_max_dist,
+        )
+        logger.info(f"  tx-neighbors-tx edges: {data['tx', 'neighbors', 'tx'].edge_index.shape[1]:,}")
+    else:
+        logger.info("  tx-neighbors-tx edges: 0 (ablated via use_tx_tx_edges=False)")
 
     # Reference segmentation graph
     logger.debug("Setting up segmentation graph")

--- a/src/segger/models/ist_encoder.py
+++ b/src/segger/models/ist_encoder.py
@@ -1,4 +1,4 @@
-from torch_geometric.nn import GATv2Conv, Linear, HeteroDictLinear, HeteroConv
+from torch_geometric.nn import GATv2Conv, SAGEConv, Linear, HeteroDictLinear, HeteroConv
 from typing import Dict, Tuple, List, Union, Optional
 from torch import Tensor
 from torch.nn import (
@@ -102,46 +102,62 @@ class SkipGAT(Module):
         out_channels: int,
         n_heads: int,
         add_self_loops_tx: bool = False,
+        aggregation: str = 'gatv2',
     ) -> None:
         super().__init__()
 
-        # Build a HeteroConv that internally uses GATv2Conv for each edge type.
-        self.conv = HeteroConv(
-            convs={
-                ('tx', 'neighbors', 'tx'): GATv2Conv(
+        self.aggregation = aggregation
+        edge_types = [
+            ('tx', 'neighbors', 'tx'),
+            ('tx', 'belongs', 'bd'),
+            ('bd', 'contains', 'tx'),
+        ]
+
+        if aggregation == 'gatv2':
+            # Attention-based message passing (default Segger).
+            convs = {
+                et: GATv2Conv(
                     in_channels=in_channels,
                     out_channels=out_channels,
                     heads=n_heads,
-                    add_self_loops=add_self_loops_tx,
+                    add_self_loops=add_self_loops_tx if et == edge_types[0] else False,
                     dropout=0.2,
-                ),
-                ('tx', 'belongs', 'bd'): GATv2Conv(
+                )
+                for et in edge_types
+            }
+        elif aggregation == 'mean':
+            # Ablation: attention removed, replaced with mean aggregation
+            # (SAGEConv). Output width is matched to GATv2's concatenated
+            # heads (out_channels * n_heads) so that only the attention
+            # mechanism is removed and overall model capacity is held fixed.
+            convs = {
+                et: SAGEConv(
                     in_channels=in_channels,
-                    out_channels=out_channels,
-                    heads=n_heads,
-                    add_self_loops=False,
-                    dropout=0.2,
-                ),
-                ('bd', 'contains', 'tx'): GATv2Conv(
-                    in_channels=in_channels,
-                    out_channels=out_channels,
-                    heads=n_heads,
-                    add_self_loops=False,
-                    dropout=0.2,
-                ),
-            },
-            aggr='sum'
-        )
+                    out_channels=out_channels * n_heads,
+                    aggr='mean',
+                )
+                for et in edge_types
+            }
+        else:
+            raise ValueError(
+                f"Unrecognized aggregation: '{aggregation}'. "
+                f"Acceptable values are 'gatv2' and 'mean'."
+            )
+
+        # Build a HeteroConv that internally uses one conv per edge type.
+        self.conv = HeteroConv(convs=convs, aggr='sum')
 
         # This will store the attention weights from the last forward pass.
         self._attn_weights: Dict[Tuple[str, str, str], Tensor] = {}
 
         # Register a forward hook to capture attention weights internally.
-        edge_type = 'tx', 'neighbors', 'tx'
-        self.conv.convs[edge_type].register_forward_hook(
-            self._make_hook(edge_type),
-            with_kwargs=True,
-        )
+        # Only meaningful for the attention-based (gatv2) variant.
+        if aggregation == 'gatv2':
+            edge_type = 'tx', 'neighbors', 'tx'
+            self.conv.convs[edge_type].register_forward_hook(
+                self._make_hook(edge_type),
+                with_kwargs=True,
+            )
 
     def _make_hook(self, edge_type: Tuple[str, str, str]):
         """
@@ -179,14 +195,18 @@ class SkipGAT(Module):
         x_dict_out : dict of str -> Tensor
             Updated node embeddings after convolution.
         """
-        # Always request attention weights, but do not return them here.
-        x_dict = self.conv(
-            x_dict,
-            edge_index_dict,
-            return_attention_weights_dict = {
-                edge: False for edge in self.conv.convs
-            },
-        )
+        # Request attention weights only for the attention-based variant;
+        # SAGEConv (mean aggregation) does not accept this argument.
+        if self.aggregation == 'gatv2':
+            x_dict = self.conv(
+                x_dict,
+                edge_index_dict,
+                return_attention_weights_dict = {
+                    edge: False for edge in self.conv.convs
+                },
+            )
+        else:
+            x_dict = self.conv(x_dict, edge_index_dict)
         return x_dict
 
     @property
@@ -226,6 +246,7 @@ class ISTEncoder(torch.nn.Module):
         n_heads: int = 3,
         normalize_embeddings: bool = True,
         use_positional_embeddings: bool = True,
+        aggregation: str = 'gatv2',
     ):
         """
         Initialize the Segger model.
@@ -267,16 +288,16 @@ class ISTEncoder(torch.nn.Module):
         self.conv_layers = ModuleList()
         # First convolution: in -> hidden x heads
         self.conv_layers.append(
-            SkipGAT((-1, -1), hidden_channels, n_heads)
+            SkipGAT((-1, -1), hidden_channels, n_heads, aggregation=aggregation)
         )
         # Middle convolutions: hidden x heads -> hidden x heads
         for _ in range(n_mid_layers):
             self.conv_layers.append(
-                SkipGAT((-1, -1), hidden_channels, n_heads)
+                SkipGAT((-1, -1), hidden_channels, n_heads, aggregation=aggregation)
             )
         # Last convolution: hidden x heads -> out x heads
         self.conv_layers.append(
-            SkipGAT((-1, -1), out_channels, n_heads)
+            SkipGAT((-1, -1), out_channels, n_heads, aggregation=aggregation)
         )
         # Last layer: out x heads -> out
         self.lin_last = HeteroDictLinear(

--- a/src/segger/models/lightning_model.py
+++ b/src/segger/models/lightning_model.py
@@ -45,6 +45,7 @@ class LitISTEncoder(LightningModule):
         update_gene_embedding: bool = True,
         use_positional_embeddings: bool = True,
         normalize_embeddings: bool = True,
+        aggregation: str = 'gatv2',
     ):
         """TODO: Description.
 
@@ -66,6 +67,7 @@ class LitISTEncoder(LightningModule):
             n_heads=n_heads,
             normalize_embeddings=normalize_embeddings,
             use_positional_embeddings=use_positional_embeddings,
+            aggregation=aggregation,
         )
         self.learning_rate = learning_rate
         self._sg_loss_type = sg_loss_type

--- a/tests/test_ablation_flags.py
+++ b/tests/test_ablation_flags.py
@@ -1,0 +1,133 @@
+"""CPU unit tests for the architecture-ablation flags (feat/ablation-flags).
+
+Validates the two reviewer-requested component ablations at the model layer,
+without importing the full ``segger`` package (which pulls GPU-only deps such
+as ``cupy``). The encoder module is loaded directly from its file path, so this
+test only needs ``torch`` + ``torch_geometric`` on CPU.
+
+Covered:
+  * ``--aggregation gatv2`` (default): attention path runs and stores weights.
+  * ``--aggregation mean``: attention removed (SAGEConv mean), width matched to
+    the attention heads, forward runs, no attention weights are stored.
+  * ``--no-tx-tx-edges`` (omit the ('tx','neighbors','tx') edge type): forward
+    runs for BOTH aggregation modes; transcript nodes are still updated via the
+    ('bd','contains','tx') edges (HeteroConv tolerates the missing edge type).
+
+Run inside the segger env:  pytest tests/test_ablation_flags.py -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+from torch_geometric.data import HeteroData  # noqa: E402
+
+_ENC_PATH = pathlib.Path(__file__).resolve().parents[1] / "src/segger/models/ist_encoder.py"
+
+
+def _load_encoder_module():
+    """Load ist_encoder.py directly, bypassing the heavy segger package __init__."""
+    spec = importlib.util.spec_from_file_location("_ist_encoder_standalone", _ENC_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+enc = _load_encoder_module()
+
+N_GENES = 30
+IN_CH = 8
+OUT_CH = 8
+N_HEADS = 2
+
+
+def _toy_inputs(n_tx=24, n_bd=6, with_tx_tx=True, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    data = HeteroData()
+    # tx node features are gene-token indices -> Embedding(n_genes, in_ch)
+    data["tx"].x = torch.randint(0, N_GENES, (n_tx,), generator=g)
+    data["bd"].x = torch.randn(n_bd, IN_CH, generator=g)
+    data["tx"].pos = torch.rand(n_tx, 2, generator=g)
+    data["bd"].pos = torch.rand(n_bd, 2, generator=g)
+
+    # belongs / contains: ensure every tx has a contains edge so tx nodes are
+    # always updated even when tx-tx edges are removed.
+    src = torch.arange(n_tx)
+    dst = torch.randint(0, n_bd, (n_tx,), generator=g)
+    data["tx", "belongs", "bd"].edge_index = torch.stack([src, dst])
+    data["bd", "contains", "tx"].edge_index = torch.stack([dst, src])
+    if with_tx_tx:
+        e = torch.randint(0, n_tx, (2, 3 * n_tx), generator=g)
+        data["tx", "neighbors", "tx"].edge_index = e
+
+    x_dict = {"tx": data["tx"].x, "bd": data["bd"].x}
+    pos_dict = {"tx": data["tx"].pos, "bd": data["bd"].pos}
+    batch_dict = {
+        "tx": torch.zeros(n_tx, dtype=torch.long),
+        "bd": torch.zeros(n_bd, dtype=torch.long),
+    }
+    return data, x_dict, pos_dict, batch_dict
+
+
+def _build(aggregation):
+    return enc.ISTEncoder(
+        n_genes=N_GENES,
+        in_channels=IN_CH,
+        hidden_channels=OUT_CH,
+        out_channels=OUT_CH,
+        n_mid_layers=1,
+        n_heads=N_HEADS,
+        aggregation=aggregation,
+    )
+
+
+@pytest.mark.parametrize("with_tx_tx", [True, False])
+def test_gatv2_forward(with_tx_tx):
+    model = _build("gatv2").eval()
+    data, x, pos, batch = _toy_inputs(with_tx_tx=with_tx_tx)
+    out = model(x, data.edge_index_dict, pos, batch)
+    assert out["tx"].shape == (data["tx"].num_nodes, OUT_CH)
+    assert out["bd"].shape == (data["bd"].num_nodes, OUT_CH)
+    assert torch.isfinite(out["tx"]).all() and torch.isfinite(out["bd"]).all()
+    # default normalize_embeddings=True -> unit-norm rows
+    assert torch.allclose(out["tx"].norm(dim=-1), torch.ones(out["tx"].shape[0]), atol=1e-4)
+    if with_tx_tx:
+        # attention weights captured by the hook on the tx-tx conv
+        assert model.conv_layers[0].attention_weights  # non-empty dict
+
+
+@pytest.mark.parametrize("with_tx_tx", [True, False])
+def test_mean_forward(with_tx_tx):
+    model = _build("mean").eval()
+    data, x, pos, batch = _toy_inputs(with_tx_tx=with_tx_tx)
+    out = model(x, data.edge_index_dict, pos, batch)
+    assert out["tx"].shape == (data["tx"].num_nodes, OUT_CH)
+    assert out["bd"].shape == (data["bd"].num_nodes, OUT_CH)
+    assert torch.isfinite(out["tx"]).all() and torch.isfinite(out["bd"]).all()
+    # mean aggregation stores no attention weights
+    with pytest.raises(AttributeError):
+        _ = model.conv_layers[0].attention_weights
+
+
+def test_mean_layer_width_matches_heads():
+    """SAGEConv output width must equal GATv2 concat width (out_channels * n_heads)."""
+    layer = enc.SkipGAT((-1, -1), OUT_CH, N_HEADS, aggregation="mean")
+    sage = layer.conv.convs[("tx", "neighbors", "tx")]
+    assert sage.out_channels == OUT_CH * N_HEADS
+
+
+def test_no_tx_tx_changes_output():
+    """Removing tx-tx edges should change tx embeddings (the ablation has an effect)."""
+    torch.manual_seed(0)
+    model = _build("gatv2").eval()
+    _, x, pos, batch = _toy_inputs(with_tx_tx=True)
+    data_full, *_ = _toy_inputs(with_tx_tx=True)
+    data_no, *_ = _toy_inputs(with_tx_tx=False)
+    out_full = model(x, data_full.edge_index_dict, pos, batch)
+    out_no = model(x, data_no.edge_index_dict, pos, batch)
+    assert not torch.allclose(out_full["tx"], out_no["tx"], atol=1e-5)


### PR DESCRIPTION
## What

Adds two **additive, flag-gated** architecture ablations to `segger segment`, for the revision's component-ablation subfigure. Defaults reproduce current behaviour exactly.

- **`--aggregation {gatv2,mean}`** — `mean` removes attention, replacing GATv2 with a mean-aggregation `SAGEConv` whose width is matched to the attention heads (`out_channels * n_heads`), so *only* the attention mechanism is ablated (capacity held fixed). The attention hook / `return_attention_weights` path is guarded for the mean variant.
- **`--no-tx-tx-edges`** — omits the `('tx','neighbors','tx')` edge type entirely; `HeteroConv` natively tolerates the missing edge type, so transcript nodes update only via `('bd','contains','tx')`.

## Why

Directly answers reviewer requests that the manuscript does not yet cover — it varies attention **head count** and tx-graph **k/dist**, but never *removes* attention or the transcript–transcript edges:
- R2.7 (verbatim): *"would a simpler message-passing network without attention perform comparably?"* + ablation of *"spatial transcript–transcript edges."*
- R1.1: isolate *"transcript neighbourhood structure ... and the attention-based message passing mechanism."*

## Touched files

`models/ist_encoder.py`, `models/lightning_model.py`, `data/data_module.py`, `data/utils/heterodata.py`, `cli/segment.py` (+103/−46). New: `tests/test_ablation_flags.py` (CPU, layer-level: both aggregation modes × tx-tx on/off; verifies SAGEConv width match, hook guard, and that removing tx-tx changes embeddings).

## Validation

- All edited files compile; layer-level tests pass in a `torch_geometric` env.
- Defaults unchanged → parity with current model.

The mask-perturbation builder, LSF sweep submitter, and figure scripts that drive the 2D component × mask-degradation study live with the experiment scripts (not in this package PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)