### PR TITLE
fix(cli): correct segment --debug default (was the string "none")

### DIFF
--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -309,7 +309,7 @@ def segment(
     
     debug: Annotated[bool, Parameter(
         help="Whether to save additional debug information (trainer, predictions).",
-    )] = "none",
+    )] = False,
 ):
     """Run cell segmentation on spatial transcriptomics data."""
 


### PR DESCRIPTION
The `debug` flag is typed bool but defaulted to the string "none"; default to False.