### PR TITLE
fix(model): guard prediction against empty tiles

### DIFF
--- a/src/segger/models/ist_encoder.py
+++ b/src/segger/models/ist_encoder.py
@@ -59,10 +59,16 @@ class Positional2dEmbedder(Module):
             pos: torch.Tensor,
             batch: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if pos.numel() == 0:
+            return pos.new_zeros((pos.shape[0], self.dim * 2))
+
         if batch is None:
             pos = pos - pos.min(dim=0).values
             pos = pos / pos.max(dim=0).values
         else:
+            if batch.numel() == 0:
+                return pos.new_zeros((pos.shape[0], self.dim * 2))
+            batch = batch.to(torch.long)
             # normalize per batch
             mins = torch.zeros((batch.max()+1, 2), device=pos.device)
             maxs = torch.zeros((batch.max()+1, 2), device=pos.device)

--- a/src/segger/models/lightning_model.py
+++ b/src/segger/models/lightning_model.py
@@ -283,7 +283,7 @@ class LitISTEncoder(LightningModule):
             dim_size=batch['tx'].num_nodes,
         )
         # Filter by similarity
-        valid = max_idx < dst.shape[0]
+        valid = (max_idx >= 0) & (max_idx < dst.shape[0])
         if min_similarity is not None:
             valid &= max_sim >= min_similarity
 


### PR DESCRIPTION
Two robustness fixes that surface on sparse/empty tiles (common at scale, e.g. MERSCOPE):
- LitISTEncoder.predict_step: scatter_max returns -1 for transcripts with no candidate boundary; main only checked `max_idx < dst.shape[0]` so a -1 was treated as valid and indexed wrongly. Add the `max_idx >= 0` guard.
- Positional2dEmbedder.forward: return zeros for empty `pos`/`batch` instead of crashing on min/max over an empty tensor; cast batch to long.

What to review: the one-line `valid` guard in lightning_model.py and the two empty-tensor early-returns in ist_encoder.py. No behavior change on non-empty input.