### PR TITLE
Add segger export for scverse-compatible output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ __marimo__/
 .dev/*
 *.pyc
 *memray*
+rmm_log.txt
+/nvidia/

--- a/README.md
+++ b/README.md
@@ -64,3 +64,24 @@ To see all available parameter options:
 ```bash
 segger segment --help
 ```
+
+## Exporting segmentation outputs for interoperability
+
+`segger export` writes a segger segmentation to plain files from which a SpatialData object can be
+assembled. Name which elements to write: `anndata` (cell by gene table), `transcripts` (the assigned
+transcripts), or `boundaries` (one polygon per cell). With no element named it writes `anndata` and
+`boundaries`; add `transcripts` for the per-transcript assignment.
+```bash
+segger export                     -s outputs/segger_segmentation.parquet -i /path/to/ist/data/ -o export/   # anndata.h5ad + cell_boundaries.parquet
+segger export anndata transcripts -s outputs/segger_segmentation.parquet -i /path/to/ist/data/ -o export/   # select which elements to write
+```
+Boundaries are traced with `--method`: `delaunay` (the default) prunes a Delaunay triangulation into a
+concave outline, while `convex_hull` takes the convex hull; both are Chaikin-smoothed unless
+`--no-smooth-masks`. The exported transcripts are controlled by `--include-all-transcripts`,
+`--min-similarity`, and `--min-transcripts` (see `segger export --help`).
+
+The column names follow SOPA's SpatialData conventions. `anndata.h5ad` and `cell_boundaries.parquet`
+share `cell_id`, the instance key SOPA uses to join a table to its shapes. `transcripts.parquet` keeps
+the segger assignment as `segger_cell_id` (plus `row_index`), a sibling column in the spirit of SOPA's
+`sopa_prior`, so it merges onto an existing transcripts dataframe by `row_index` without overwriting
+the vendor `cell_id`; its values match the `cell_id` in the other two files.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ segger export                     -s outputs/segger_segmentation.parquet -i /pat
 segger export anndata transcripts -s outputs/segger_segmentation.parquet -i /path/to/ist/data/ -o export/   # select which elements to write
 ```
 Boundaries are traced with `--method`: `delaunay` (the default) prunes a Delaunay triangulation into a
-concave outline, while `convex_hull` takes the convex hull; both are Chaikin-smoothed unless
-`--no-smooth-masks`. The exported transcripts are controlled by `--include-all-transcripts`,
-`--min-similarity`, and `--min-transcripts` (see `segger export --help`).
+concave outline, while `convex_hull` takes the convex hull; neither is smoothed by default, but
+`--chaikin-iterations` rounds them with that many rounds of Chaikin corner-cutting. The exported
+transcripts are controlled by `--include-all-transcripts`, `--min-similarity`, and `--min-transcripts`
+(see `segger export --help`).
 
 The column names follow SOPA's SpatialData conventions. `anndata.h5ad` and `cell_boundaries.parquet`
 share `cell_id`, the instance key SOPA uses to join a table to its shapes. `transcripts.parquet` keeps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "shapely",
     "scikit-image",
     "scikit-learn",
-    "tifffile"
+    "tifffile",
+    "tqdm"
 ]
 
 [build-system]

--- a/src/segger/cli/export.py
+++ b/src/segger/cli/export.py
@@ -103,7 +103,9 @@ def export(
         Literal["delaunay", "convex_hull"],
         Parameter(group=_group_opts, help="Cell-polygon method for boundaries."),
     ] = "delaunay",
-    smooth_masks: Annotated[bool, Parameter(group=_group_opts, help="Round boundaries with Chaikin smoothing.")] = True,
+    chaikin_iterations: Annotated[
+        int, Parameter(group=_group_opts, help="Chaikin corner-cutting iterations to round boundaries (0 disables).")
+    ] = 0,
     include_all_transcripts: _IncludeAll = False,
     min_similarity: _MinSim = None,
     min_transcripts: _MinTx = 10,
@@ -117,7 +119,7 @@ def export(
     if "boundaries" in selected:
         from ..export import generate_boundaries
 
-        gdf = generate_boundaries(assigned, cell_id="segger_cell_id", method=method, smoothing=2 if smooth_masks else 0)
+        gdf = generate_boundaries(assigned, cell_id="segger_cell_id", method=method, smoothing=chaikin_iterations)
         gdf.to_parquet(output_directory / "cell_boundaries.parquet")
         print(f"Wrote {len(gdf)} {method} cell boundaries: {output_directory / 'cell_boundaries.parquet'}")
 

--- a/src/segger/cli/export.py
+++ b/src/segger/cli/export.py
@@ -1,7 +1,7 @@
 """``segger export``: write a segger segmentation as scverse-compatible files.
 
 One command writes the chosen SpatialData elements: ``anndata`` the cell by gene table
-(``anndata.h5ad``), ``transcripts`` the assigned transcripts/points (``transcripts.parquet``),
+(``adata.h5ad``), ``transcripts`` the assigned transcripts/points (``transcripts.parquet``),
 and ``boundaries`` one polygon per cell/shapes (``cell_boundaries.parquet``). Default: anndata + boundaries.
 """
 
@@ -128,8 +128,8 @@ def export(
 
         # Use the exported polygon areas so obs["area"] matches the boundaries; omitted otherwise.
         adata = build_anndata(assigned, cell_id="segger_cell_id", area=gdf.geometry.area if gdf is not None else None)
-        adata.write_h5ad(output_directory / "anndata.h5ad")
-        print(f"Wrote AnnData ({adata.n_obs} cells x {adata.n_vars} genes): {output_directory / 'anndata.h5ad'}")
+        adata.write_h5ad(output_directory / "adata.h5ad")
+        print(f"Wrote AnnData ({adata.n_obs} cells x {adata.n_vars} genes): {output_directory / 'adata.h5ad'}")
 
     if "transcripts" in selected:
         assigned.write_parquet(output_directory / "transcripts.parquet")

--- a/src/segger/cli/export.py
+++ b/src/segger/cli/export.py
@@ -1,0 +1,134 @@
+"""``segger export``: write a segger segmentation as scverse-compatible files.
+
+One command writes the chosen SpatialData elements: ``anndata`` the cell by gene table
+(``anndata.h5ad``), ``transcripts`` the assigned transcripts/points (``transcripts.parquet``),
+and ``boundaries`` one polygon per cell/shapes (``cell_boundaries.parquet``). Default: anndata + boundaries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal, Optional
+
+from cyclopts import Parameter, Group, validators
+
+_group_io = Group(name="I/O", sort_key=0)
+_group_opts = Group(name="Options", sort_key=1)
+
+_Element = Literal["anndata", "transcripts", "boundaries"]
+_DEFAULT_ELEMENTS = ("anndata", "boundaries")
+
+_Seg = Annotated[Path, Parameter(alias="-s", group=_group_io, validator=validators.Path(exists=True, dir_okay=False))]
+_Source = Annotated[Path, Parameter(alias="-i", group=_group_io, validator=validators.Path(exists=True, dir_okay=True))]
+_Out = Annotated[Path, Parameter(alias="-o", group=_group_io)]
+
+_IncludeAll = Annotated[
+    bool,
+    Parameter(group=_group_opts, help="Keep every cell-assigned transcript, ignoring the similarity threshold."),
+]
+_MinSim = Annotated[
+    Optional[float],
+    Parameter(
+        group=_group_opts,
+        validator=validators.Number(gte=0, lte=1),
+        help="Fixed similarity threshold (0-1), overriding the per-gene threshold from segmentation.",
+    ),
+]
+_MinTx = Annotated[
+    int,
+    Parameter(
+        group=_group_opts,
+        validator=validators.Number(gte=0),
+        help="Minimum number of assigned transcripts a cell must have to be included.",
+    ),
+]
+
+
+def _load_assigned(
+    segmentation_path: Path,
+    source_path: Path,
+    include_all_transcripts: bool,
+    min_similarity: Optional[float],
+    min_transcripts: int = 10,
+) -> "pl.DataFrame":
+    """Join predictions onto source transcripts; return the kept tx (row_index/segger_cell_id/feature_name/x/y)."""
+    import polars as pl
+
+    from ..io import StandardTranscriptFields, get_preprocessor
+
+    std = StandardTranscriptFields()
+    seg = pl.read_parquet(segmentation_path)
+    if "segger_cell_id" not in seg.columns:
+        raise ValueError(f"No 'segger_cell_id' column in {segmentation_path}.")
+
+    tx = get_preprocessor(source_path).transcripts
+    if isinstance(tx, pl.LazyFrame):
+        tx = tx.collect()
+
+    pred_cols = [c for c in (std.row_index, "segger_cell_id", "segger_similarity", "similarity_threshold") if c in seg.columns]
+    merged = tx.join(seg.select(pred_cols), on=std.row_index, how="left")
+
+    has_assignment = pl.col("segger_cell_id").is_not_null()
+    if include_all_transcripts:
+        keep = has_assignment
+    elif min_similarity is not None:
+        if "segger_similarity" not in merged.columns:
+            raise ValueError("--min-similarity needs a 'segger_similarity' column in the segmentation file.")
+        keep = has_assignment & (pl.col("segger_similarity") >= min_similarity)
+    elif {"segger_similarity", "similarity_threshold"} <= set(merged.columns):
+        keep = has_assignment & (pl.col("segger_similarity") >= pl.col("similarity_threshold"))
+    else:
+        keep = has_assignment
+
+    assigned = merged.filter(keep).select(
+        pl.col(std.row_index),
+        pl.col("segger_cell_id").cast(pl.String),
+        pl.col(std.feature).alias("feature_name"),
+        pl.col(std.x).alias("x"),
+        pl.col(std.y).alias("y"),
+    )
+
+    if min_transcripts > 0:
+        assigned = assigned.filter(pl.len().over("segger_cell_id") >= min_transcripts)
+
+    return assigned
+
+
+def export(
+    *elements: Annotated[_Element, Parameter(help="Elements to write (default: anndata boundaries).")],
+    segmentation_path: _Seg,
+    source_path: _Source,
+    output_directory: _Out,
+    method: Annotated[
+        Literal["delaunay", "convex_hull"],
+        Parameter(group=_group_opts, help="Cell-polygon method for boundaries."),
+    ] = "delaunay",
+    smooth_masks: Annotated[bool, Parameter(group=_group_opts, help="Round boundaries with Chaikin smoothing.")] = True,
+    include_all_transcripts: _IncludeAll = False,
+    min_similarity: _MinSim = None,
+    min_transcripts: _MinTx = 10,
+):
+    """Write a segger segmentation as scverse SpatialData elements (anndata, transcripts, boundaries)."""
+    selected = elements or _DEFAULT_ELEMENTS
+    assigned = _load_assigned(segmentation_path, source_path, include_all_transcripts, min_similarity, min_transcripts)
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    gdf = None
+    if "boundaries" in selected:
+        from ..export import generate_boundaries
+
+        gdf = generate_boundaries(assigned, cell_id="segger_cell_id", method=method, smoothing=2 if smooth_masks else 0)
+        gdf.to_parquet(output_directory / "cell_boundaries.parquet")
+        print(f"Wrote {len(gdf)} {method} cell boundaries: {output_directory / 'cell_boundaries.parquet'}")
+
+    if "anndata" in selected:
+        from ..export import build_anndata
+
+        # Use the exported polygon areas so obs["area"] matches the boundaries; omitted otherwise.
+        adata = build_anndata(assigned, cell_id="segger_cell_id", area=gdf.geometry.area if gdf is not None else None)
+        adata.write_h5ad(output_directory / "anndata.h5ad")
+        print(f"Wrote AnnData ({adata.n_obs} cells x {adata.n_vars} genes): {output_directory / 'anndata.h5ad'}")
+
+    if "transcripts" in selected:
+        assigned.write_parquet(output_directory / "transcripts.parquet")
+        print(f"Wrote {assigned.height} assigned transcripts: {output_directory / 'transcripts.parquet'}")

--- a/src/segger/cli/main.py
+++ b/src/segger/cli/main.py
@@ -1,12 +1,10 @@
 from cyclopts import App
 from .segment import segment
 from .debug import debug
+from .export import export
 
-# CLI App
 app = App(name="Segger")
 
-# Main segmentation
 app.command(segment)
-
-# Debugging utilities
 app.command(debug)
+app.command(export)

--- a/src/segger/data/utils/anndata.py
+++ b/src/segger/data/utils/anndata.py
@@ -1,5 +1,3 @@
-from email.message import Message
-
 from torch.nn.functional import normalize
 from scipy import sparse as sp
 import geopandas as gpd
@@ -9,13 +7,13 @@ import scanpy as sc
 import numpy as np
 import sklearn
 import torch
-import cupyx
-import cuml
 import warnings
 
 from ...io.fields import TrainingTranscriptFields, TrainingBoundaryFields
-from .neighbors import phenograph_rapids
 from segger.geometry.morphology import get_polygon_props
+
+# cupyx/cuml/phenograph_rapids are imported inside setup_anndata so anndata_from_transcripts
+# stays importable without a GPU (e.g. for segger export on a CPU-only machine).
 
 def anndata_from_transcripts(
     tx: pl.DataFrame,
@@ -146,6 +144,10 @@ def setup_anndata(
     gene_missing_strategy: str = "error",
 ):
     """TODO: Add description."""
+    import cupyx
+    import cuml
+    from .neighbors import phenograph_rapids
+
     # Standard fields
     tx_fields = TrainingTranscriptFields()
     bd_fields = TrainingBoundaryFields()

--- a/src/segger/export/__init__.py
+++ b/src/segger/export/__init__.py
@@ -1,0 +1,8 @@
+"""Export a segger segmentation as scverse-compatible objects: a cell x gene ``AnnData``
+table (:func:`build_anndata`) and a ``GeoDataFrame`` of cell-boundary polygons
+(:func:`generate_boundaries`), sharing cell ids and coordinate space."""
+
+from .anndata_writer import build_anndata
+from .boundary import generate_boundaries
+
+__all__ = ["build_anndata", "generate_boundaries"]

--- a/src/segger/export/anndata_writer.py
+++ b/src/segger/export/anndata_writer.py
@@ -1,0 +1,45 @@
+"""Cell x gene AnnData from assigned transcripts (the scverse table element)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+import polars as pl
+from anndata import AnnData
+
+
+def build_anndata(
+    assigned: pl.DataFrame,
+    cell_id: str = "cell_id",
+    feature: str = "feature_name",
+    x: str = "x",
+    y: str = "y",
+    region: str = "cell_boundaries",
+    area: Optional[pd.Series] = None,
+) -> AnnData:
+    """Cell x gene table built on :func:`anndata_from_transcripts`, with the SpatialData link added.
+
+    ``obs`` is indexed by the cell id; centroids land in ``obsm["spatial"]`` and the table-to-shapes
+    link in ``uns["spatialdata_attrs"]``. ``area`` (a per-cell Series, e.g. the exported boundary
+    polygon areas) is written to ``obs["area"]`` when given.
+    """
+    from ..data.utils.anndata import anndata_from_transcripts
+
+    adata = anndata_from_transcripts(
+        assigned, feature_column=feature, cell_id_column=cell_id, coordinate_columns=[x, y]
+    )
+    if "X_spatial" in adata.obsm:
+        adata.obsm["spatial"] = adata.obsm.pop("X_spatial")
+
+    counts = assigned.group_by(cell_id).len().to_pandas().set_index(cell_id)["len"]
+    adata.obs["n_transcripts"] = counts.reindex(adata.obs_names).to_numpy()
+    if area is not None:
+        adata.obs["area"] = pd.Series(area).reindex(adata.obs_names).to_numpy()
+
+    # SpatialData link: region/instance_key obs columns plus the attrs that join table to shapes.
+    adata.obs["region"] = pd.Categorical([region] * adata.n_obs, categories=[region])
+    adata.obs["cell_id"] = adata.obs_names.to_numpy()
+    adata.obs.index.name = None
+    adata.uns["spatialdata_attrs"] = {"region": region, "region_key": "region", "instance_key": "cell_id"}
+    return adata

--- a/src/segger/export/boundary.py
+++ b/src/segger/export/boundary.py
@@ -16,6 +16,7 @@ import polars as pl
 from scipy.spatial import Delaunay, cKDTree
 from shapely.geometry import LineString, MultiPoint, Polygon
 from shapely.ops import polygonize
+from tqdm import tqdm
 
 
 def _as_polygon(geom) -> Optional[Polygon]:
@@ -124,7 +125,7 @@ class _CellOutline:
                     nxt.append(edge)
             boundary = nxt
 
-    def refine(self, connectivity: float = 1.0) -> "_CellOutline":
+    def refine(self, connectivity: float = 2.0) -> "_CellOutline":
         """Prune the triangulation to a concave outline.
 
         ``connectivity`` scales how readily boundary edges are pruned: 1.0 reproduces the
@@ -156,8 +157,8 @@ class _CellOutline:
 def cell_boundary(
     points: np.ndarray,
     method: Literal["delaunay", "convex_hull"] = "delaunay",
-    smoothing: int = 2,
-    connectivity: float = 1.0,
+    smoothing: int = 0,
+    connectivity: float = 2.0,
 ) -> Optional[Polygon]:
     """Boundary polygon for one cell's transcript coordinates, or None if degenerate.
 
@@ -189,18 +190,21 @@ def generate_boundaries(
     x: str = "x",
     y: str = "y",
     method: Literal["delaunay", "convex_hull"] = "delaunay",
-    smoothing: int = 2,
-    connectivity: float = 1.0,
+    smoothing: int = 0,
+    connectivity: float = 2.0,
 ) -> gpd.GeoDataFrame:
     """Build a GeoDataFrame of cell polygons (indexed by ``cell_id``) from assigned transcripts."""
     if isinstance(transcripts, pl.DataFrame):
         grouped = transcripts.group_by(cell_id).agg(pl.col(x), pl.col(y))
+        n_groups = grouped.height
         groups = ((cid, np.column_stack((xs, ys))) for cid, xs, ys in grouped.iter_rows())
     else:
-        groups = ((cid, g[[x, y]].to_numpy()) for cid, g in transcripts.groupby(cell_id))
+        grouped = transcripts.groupby(cell_id)
+        n_groups = grouped.ngroups
+        groups = ((cid, g[[x, y]].to_numpy()) for cid, g in grouped)
 
     ids, n_tx, geoms = [], [], []
-    for cid, pts in groups:
+    for cid, pts in tqdm(groups, total=n_groups, desc="Building cell boundaries"):
         ids.append(str(cid))
         n_tx.append(len(pts))
         geoms.append(cell_boundary(pts, method=method, smoothing=smoothing, connectivity=connectivity))

--- a/src/segger/export/boundary.py
+++ b/src/segger/export/boundary.py
@@ -1,0 +1,182 @@
+"""Cell-boundary polygons from a cell's assigned transcripts.
+
+``convex_hull`` takes the points' convex hull; ``delaunay`` prunes long/sharp edges
+off the Delaunay triangulation for a tighter concave outline. Either is optionally
+rounded with Chaikin smoothing. One Shapely polygon per cell.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional, Union
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import polars as pl
+from scipy.spatial import Delaunay, cKDTree
+from shapely.geometry import LineString, MultiPoint, Polygon
+from shapely.ops import polygonize
+
+
+def _as_polygon(geom) -> Optional[Polygon]:
+    """Normalize a Shapely geometry to a single non-empty Polygon (largest part), else None."""
+    if geom is None or geom.is_empty:
+        return None
+    if geom.geom_type == "MultiPolygon":
+        geom = max(geom.geoms, key=lambda p: p.area)
+    return geom if geom.geom_type == "Polygon" and not geom.is_empty else None
+
+
+def _triangle_angles(points: np.ndarray, simplices: np.ndarray) -> np.ndarray:
+    """Interior angles (degrees) at each of the three vertices of every triangle."""
+    p0, p1, p2 = points[simplices[:, 0]], points[simplices[:, 1]], points[simplices[:, 2]]
+
+    def angle(u: np.ndarray, v: np.ndarray) -> np.ndarray:
+        cos = (u * v).sum(1) / (np.linalg.norm(u, axis=1) * np.linalg.norm(v, axis=1) + 1e-12)
+        return np.degrees(np.arccos(np.clip(cos, -1.0, 1.0)))
+
+    return np.stack([angle(p1 - p0, p2 - p0), angle(p0 - p1, p2 - p1), angle(p0 - p2, p1 - p2)], 1)
+
+
+def _chaikin(coords: np.ndarray, iterations: int) -> np.ndarray:
+    """Smooth a closed ring by Chaikin corner-cutting (``coords`` has no repeated end).
+
+    Chaikin (1974), "An algorithm for high-speed curve generation"; each iteration replaces every
+    vertex with two points at 1/4 and 3/4 along its outgoing edge.
+    """
+    for _ in range(iterations):
+        nxt = np.roll(coords, -1, axis=0)
+        smoothed = np.empty((len(coords) * 2, 2))
+        smoothed[0::2] = 0.75 * coords + 0.25 * nxt
+        smoothed[1::2] = 0.25 * coords + 0.75 * nxt
+        coords = smoothed
+    return coords
+
+
+class _CellOutline:
+    """Prune a cell's Delaunay triangulation to a single concave boundary polygon."""
+
+    def __init__(self, points: np.ndarray):
+        self.tri = Delaunay(points)
+        self.points = self.tri.points
+        self.d_max = self._nn_max(self.points)
+        self.edges = self._build_edges()
+
+    @staticmethod
+    def _nn_max(points: np.ndarray) -> float:
+        """Largest nearest-neighbor distance, the edge-length scale of the cloud."""
+        dist, _ = cKDTree(points).query(points, k=2)
+        return float(dist[:, 1].max())
+
+    @staticmethod
+    def _simplex_edges(simplex: np.ndarray) -> list:
+        return [tuple(sorted((simplex[i], simplex[(i + 1) % 3]))) for i in range(3)]
+
+    def _build_edges(self) -> dict:
+        """Map each edge -> {opposite-angle per incident triangle, length}."""
+        angles = _triangle_angles(self.points, self.tri.simplices)
+        edges: dict = {}
+        for ti, simplex in enumerate(self.tri.simplices):
+            for k, edge in enumerate(self._simplex_edges(simplex)):
+                if edge not in edges:
+                    a, b = edge
+                    edges[edge] = {"tri": {}, "length": float(np.linalg.norm(self.points[a] - self.points[b]))}
+                edges[edge]["tri"][ti] = angles[ti][(k + 2) % 3]
+        return edges
+
+    def _prune(self, predicate) -> None:
+        """Iteratively drop boundary edges (one incident triangle) matching ``predicate``."""
+        boundary = [e for e in self.edges if len(self.edges[e]["tri"]) < 2]
+        changed = True
+        while changed:
+            changed, nxt = False, []
+            for edge in boundary:
+                info = self.edges.get(edge)
+                if info is None:
+                    continue
+                if not info["tri"]:
+                    del self.edges[edge]
+                    continue
+                ti = next(iter(info["tri"]))
+                if predicate(info, ti):
+                    for other in self._simplex_edges(self.tri.simplices[ti]):
+                        if other != edge and other in self.edges:
+                            self.edges[other]["tri"].pop(ti, None)
+                            nxt.append(other)
+                    del self.edges[edge]
+                    changed = True
+                else:
+                    nxt.append(edge)
+            boundary = nxt
+
+    def refine(self) -> "_CellOutline":
+        d_max = self.d_max
+        # Phase 1: remove spuriously long boundary edges.
+        self._prune(lambda info, ti: info["length"] > 2 * d_max)
+        # Phase 2: remove boundary edges spanning very obtuse (concave) triangles.
+        self._prune(
+            lambda info, ti: (info["length"] > 1.5 * d_max and info["tri"][ti] > 90)
+            or info["tri"][ti] > 180 - 180 / 16
+        )
+        return self
+
+    def polygon(self) -> Optional[Polygon]:
+        """Polygonise the remaining boundary edges into the largest closed ring."""
+        lines = [
+            LineString([self.points[a], self.points[b]])
+            for a, b in self.edges
+            if len(self.edges[(a, b)]["tri"]) < 2
+        ]
+        polys = list(polygonize(lines))
+        return _as_polygon(max(polys, key=lambda p: p.area)) if polys else None
+
+
+def cell_boundary(
+    points: np.ndarray, method: Literal["delaunay", "convex_hull"] = "delaunay", smoothing: int = 2
+) -> Optional[Polygon]:
+    """Boundary polygon for one cell's transcript coordinates, or None if degenerate."""
+    if np.unique(points, axis=0).shape[0] < 3:
+        return None
+    if method == "convex_hull":
+        poly = _as_polygon(MultiPoint(points).convex_hull)
+    elif method == "delaunay":
+        try:
+            poly = _CellOutline(points).refine().polygon()
+        except Exception:
+            poly = None
+    else:
+        raise ValueError(f"Unknown boundary method: {method!r} (use 'delaunay' or 'convex_hull').")
+    if poly is None:
+        return None
+    if smoothing > 0:
+        poly = _as_polygon(Polygon(_chaikin(np.asarray(poly.exterior.coords)[:-1], smoothing)).buffer(0))
+    return poly
+
+
+def generate_boundaries(
+    transcripts: Union[pl.DataFrame, pd.DataFrame],
+    cell_id: str = "cell_id",
+    x: str = "x",
+    y: str = "y",
+    method: Literal["delaunay", "convex_hull"] = "delaunay",
+    smoothing: int = 2,
+) -> gpd.GeoDataFrame:
+    """Build a GeoDataFrame of cell polygons (indexed by ``cell_id``) from assigned transcripts."""
+    if isinstance(transcripts, pl.DataFrame):
+        grouped = transcripts.group_by(cell_id).agg(pl.col(x), pl.col(y))
+        groups = ((cid, np.column_stack((xs, ys))) for cid, xs, ys in grouped.iter_rows())
+    else:
+        groups = ((cid, g[[x, y]].to_numpy()) for cid, g in transcripts.groupby(cell_id))
+
+    ids, n_tx, geoms = [], [], []
+    for cid, pts in groups:
+        ids.append(str(cid))
+        n_tx.append(len(pts))
+        geoms.append(cell_boundary(pts, method=method, smoothing=smoothing))
+
+    # Output the SpatialData instance key as "cell_id" regardless of the input column name. Keep it as
+    # a column too: geoparquet drops a named index, and it must match the table instance key to join.
+    gdf = gpd.GeoDataFrame(
+        {"cell_id": ids, "n_transcripts": n_tx}, geometry=geoms, index=pd.Index(ids, name="cell_id")
+    )
+    return gdf[~gdf.geometry.isna()]

--- a/src/segger/export/boundary.py
+++ b/src/segger/export/boundary.py
@@ -61,6 +61,7 @@ class _CellOutline:
         self.points = self.tri.points
         self.d_max = self._nn_max(self.points)
         self.edges = self._build_edges()
+        self.degree = np.bincount(np.array(list(self.edges), dtype=np.int64).ravel(), minlength=len(self.points))
 
     @staticmethod
     def _nn_max(points: np.ndarray) -> float:
@@ -84,8 +85,22 @@ class _CellOutline:
                 edges[edge]["tri"][ti] = angles[ti][(k + 2) % 3]
         return edges
 
+    def _drop_edge(self, edge: tuple) -> bool:
+        """Delete ``edge`` unless doing so would leave either endpoint with no edges at all."""
+        a, b = edge
+        if self.degree[a] <= 1 or self.degree[b] <= 1:
+            return False
+        del self.edges[edge]
+        self.degree[a] -= 1
+        self.degree[b] -= 1
+        return True
+
     def _prune(self, predicate) -> None:
-        """Iteratively drop boundary edges (one incident triangle) matching ``predicate``."""
+        """Iteratively drop boundary edges (one incident triangle) matching ``predicate``.
+
+        Never drops an edge that is the last one touching either of its endpoints, so every
+        input point keeps at least one edge in the final polygon.
+        """
         boundary = [e for e in self.edges if len(self.edges[e]["tri"]) < 2]
         changed = True
         while changed:
@@ -95,28 +110,35 @@ class _CellOutline:
                 if info is None:
                     continue
                 if not info["tri"]:
-                    del self.edges[edge]
+                    if not self._drop_edge(edge):
+                        nxt.append(edge)
                     continue
                 ti = next(iter(info["tri"]))
-                if predicate(info, ti):
+                if predicate(info, ti) and self._drop_edge(edge):
                     for other in self._simplex_edges(self.tri.simplices[ti]):
                         if other != edge and other in self.edges:
                             self.edges[other]["tri"].pop(ti, None)
                             nxt.append(other)
-                    del self.edges[edge]
                     changed = True
                 else:
                     nxt.append(edge)
             boundary = nxt
 
-    def refine(self) -> "_CellOutline":
+    def refine(self, connectivity: float = 1.0) -> "_CellOutline":
+        """Prune the triangulation to a concave outline.
+
+        ``connectivity`` scales how readily boundary edges are pruned: 1.0 reproduces the
+        original thresholds, values above 1 keep more edges (more convex, better-connected
+        outlines), values below 1 prune more aggressively (tighter, more concave outlines).
+        """
         d_max = self.d_max
         # Phase 1: remove spuriously long boundary edges.
-        self._prune(lambda info, ti: info["length"] > 2 * d_max)
+        self._prune(lambda info, ti: info["length"] > 2 * connectivity * d_max)
         # Phase 2: remove boundary edges spanning very obtuse (concave) triangles.
+        max_angle = 180 - (180 / 16) / connectivity
         self._prune(
-            lambda info, ti: (info["length"] > 1.5 * d_max and info["tri"][ti] > 90)
-            or info["tri"][ti] > 180 - 180 / 16
+            lambda info, ti: (info["length"] > 1.5 * connectivity * d_max and info["tri"][ti] > 90)
+            or info["tri"][ti] > max_angle
         )
         return self
 
@@ -132,16 +154,24 @@ class _CellOutline:
 
 
 def cell_boundary(
-    points: np.ndarray, method: Literal["delaunay", "convex_hull"] = "delaunay", smoothing: int = 2
+    points: np.ndarray,
+    method: Literal["delaunay", "convex_hull"] = "delaunay",
+    smoothing: int = 2,
+    connectivity: float = 1.0,
 ) -> Optional[Polygon]:
-    """Boundary polygon for one cell's transcript coordinates, or None if degenerate."""
+    """Boundary polygon for one cell's transcript coordinates, or None if degenerate.
+
+    ``connectivity`` (``method="delaunay"`` only) scales how aggressively boundary edges are
+    pruned: 1.0 is the default, >1 keeps more edges (more convex outlines), <1 prunes more
+    (tighter, more concave outlines).
+    """
     if np.unique(points, axis=0).shape[0] < 3:
         return None
     if method == "convex_hull":
         poly = _as_polygon(MultiPoint(points).convex_hull)
     elif method == "delaunay":
         try:
-            poly = _CellOutline(points).refine().polygon()
+            poly = _CellOutline(points).refine(connectivity).polygon()
         except Exception:
             poly = None
     else:
@@ -160,6 +190,7 @@ def generate_boundaries(
     y: str = "y",
     method: Literal["delaunay", "convex_hull"] = "delaunay",
     smoothing: int = 2,
+    connectivity: float = 1.0,
 ) -> gpd.GeoDataFrame:
     """Build a GeoDataFrame of cell polygons (indexed by ``cell_id``) from assigned transcripts."""
     if isinstance(transcripts, pl.DataFrame):
@@ -172,7 +203,7 @@ def generate_boundaries(
     for cid, pts in groups:
         ids.append(str(cid))
         n_tx.append(len(pts))
-        geoms.append(cell_boundary(pts, method=method, smoothing=smoothing))
+        geoms.append(cell_boundary(pts, method=method, smoothing=smoothing, connectivity=connectivity))
 
     # Output the SpatialData instance key as "cell_id" regardless of the input column name. Keep it as
     # a column too: geoparquet drops a named index, and it must match the table instance key to join.


### PR DESCRIPTION
`segger export` writes a segger segmentation to plain files from which a `SpatialData` object can be assembled. Name which elements to write: `anndata` (the cell-by-gene table), `transcripts` (the assigned transcripts), or `boundaries` (one polygon per cell). With no element named it writes `anndata` and `boundaries`; pass `transcripts` to also write the per-transcript assignment.

The column names follow SOPA's conventions. `anndata.h5ad` and `cell_boundaries.parquet` share `cell_id`, the instance key SOPA uses to join a table to its shapes. `transcripts.parquet` keeps the segger assignment as `segger_cell_id` alongside `row_index`, a sibling column in the spirit of SOPA's `sopa_prior`, so it merges onto an existing transcripts dataframe by `row_index` without overwriting the vendor `cell_id`; its values match the `cell_id` in the other two files.

Boundaries are traced with `--method` (`delaunay`, a pruned Delaunay outline, or `convex_hull`) and Chaikin-smoothed unless `--no-smooth-masks`. The exported transcripts are selected with `--include-all-transcripts`, `--min-similarity`, and `--min-transcripts`, which default to the per-gene similarity threshold.

No new dependencies. Closes #67.