### PR TITLE
[main] Only configure RMM allocators when running the CLI

### DIFF
--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 import cupy as cp
@@ -7,23 +8,25 @@ from rmm.allocators.cupy import rmm_cupy_allocator
 from rmm.allocators.torch import rmm_torch_allocator
 from rmm.statistics import enable_statistics, get_statistics
 
+logger = logging.getLogger(__name__)
+
 
 def configure_memory(force: bool = False) -> None:
     """Point CuPy/cuDF/cuSpatial and PyTorch at a single shared RMM pool.
 
-    Must run before any CUDA tensor is created. Only called from the CLI
-    entry point (segger/cli/main.py) — importing segger as a library should
-    not mutate global CUDA allocator state as a side effect.
+    Must run before any CUDA tensor is created. Run by default from the CLI.
+    Importing segger as a library should not change already set allocators.
 
-    Note: rmm.is_initialized() is True as soon as `rmm` is imported (its
-    default, unpooled resource counts as "initialized"), so it can't be used
-    to detect whether this pool/managed-memory config was already applied.
-    We check cp's allocator directly instead — it's set together with
-    torch's in this function, so it's a reliable proxy for both.
+    Check if cp allocators are already set to RMM's pool, if not, set them.
+
+    Note: rmm.is_initialized() is True as soon as `rmm` is imported, thus
+    we can't use this to check if memory allocators are already initialised.
     """
     if not force and os.environ.get("SEGGER_SKIP_ALLOCATOR_INIT") == "1":
+        logger.info("Allocators not configured: SEGGER_SKIP_ALLOCATOR_INIT is set.")
         return
     if not force and cp.cuda.get_allocator() is rmm_cupy_allocator:
+        logger.info("Allocators not configured: RMM pool already active.")
         return
     rmm.reinitialize(pool_allocator=True, managed_memory=True)
     cp.cuda.set_allocator(rmm_cupy_allocator)

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -31,6 +31,8 @@ _apply_patches()
 
 def free_mem_str() -> str:
     stats = get_statistics()
+    if stats is None:
+        return "GPU: stats not enabled (call segger.configure_memory() first)"
     return (
         f"GPU: {stats.current_bytes / 1e9:.2f} GB "
         f"(peak {stats.peak_bytes / 1e9:.2f} GB)"

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -14,10 +14,16 @@ def configure_memory(force: bool = False) -> None:
     Must run before any CUDA tensor is created. Only called from the CLI
     entry point (segger/cli/main.py) — importing segger as a library should
     not mutate global CUDA allocator state as a side effect.
+
+    Note: rmm.is_initialized() is True as soon as `rmm` is imported (its
+    default, unpooled resource counts as "initialized"), so it can't be used
+    to detect whether this pool/managed-memory config was already applied.
+    We check cp's allocator directly instead — it's set together with
+    torch's in this function, so it's a reliable proxy for both.
     """
     if not force and os.environ.get("SEGGER_SKIP_ALLOCATOR_INIT") == "1":
         return
-    if not force and rmm.is_initialized():
+    if not force and cp.cuda.get_allocator() is rmm_cupy_allocator:
         return
     rmm.reinitialize(pool_allocator=True, managed_memory=True)
     cp.cuda.set_allocator(rmm_cupy_allocator)

--- a/src/segger/__init__.py
+++ b/src/segger/__init__.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import cupy as cp
 import torch
@@ -6,12 +7,22 @@ from rmm.allocators.cupy import rmm_cupy_allocator
 from rmm.allocators.torch import rmm_torch_allocator
 from rmm.statistics import enable_statistics, get_statistics
 
-# Single RMM pool shared by CuPy/cuDF/cuSpatial AND PyTorch. Must be set before
-# any CUDA tensor is created.
-rmm.reinitialize(pool_allocator=True, managed_memory=True)
-cp.cuda.set_allocator(rmm_cupy_allocator)
-torch.cuda.memory.change_current_allocator(rmm_torch_allocator)
-enable_statistics()
+
+def configure_memory(force: bool = False) -> None:
+    """Point CuPy/cuDF/cuSpatial and PyTorch at a single shared RMM pool.
+
+    Must run before any CUDA tensor is created. Only called from the CLI
+    entry point (segger/cli/main.py) — importing segger as a library should
+    not mutate global CUDA allocator state as a side effect.
+    """
+    if not force and os.environ.get("SEGGER_SKIP_ALLOCATOR_INIT") == "1":
+        return
+    if not force and rmm.is_initialized():
+        return
+    rmm.reinitialize(pool_allocator=True, managed_memory=True)
+    cp.cuda.set_allocator(rmm_cupy_allocator)
+    torch.cuda.memory.change_current_allocator(rmm_torch_allocator)
+    enable_statistics()
 
 # Apply pytorch patches for issue pytorch/pytorch#51871 (CUDA nonzero INT_MAX limit).
 # Must run BEFORE any segger module imports HeteroData / bipartite_subgraph.

--- a/src/segger/cli/main.py
+++ b/src/segger/cli/main.py
@@ -1,7 +1,10 @@
 from cyclopts import App
+from segger import configure_memory
 from .segment import segment
 from .debug import debug
 from .export import export
+
+configure_memory()
 
 app = App(name="Segger")
 


### PR DESCRIPTION
Moves RMM/CuPy/PyTorch allocator setup out of an unconditional import-time side effect into a guarded `configure_memory()` call invoked only from the CLI entry point.

Set `export SEGGER_SKIP_ALLOCATOR_INIT=1` to skip setting memory allocators.

Closes https://github.com/dpeerlab/segger/issues/71

Here's how to import segger interactively now:

```
import segger
segger.configure_memory()

from segger.io.preprocessor import get_preprocessor
...
```