### PR TITLE
Run Lightning on one device by default instead of every visible GPU

### DIFF
--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from ..utils import setup_logging
+from ..utils import setup_logging, resolve_trainer_devices
 
 from cyclopts import App, Parameter, Group, validators
 from typing import Annotated, Literal
@@ -310,6 +310,16 @@ def segment(
     debug: Annotated[bool, Parameter(
         help="Whether to save additional debug information (trainer, predictions).",
     )] = False,
+
+    devices: Annotated[int, Parameter(
+        validator=validators.Number(gt=0),
+        group=group_model,
+        help=(
+            "Number of accelerators to run on. Segger's cuDF/cuSpatial pipeline is "
+            "single-device; values above 1 let Lightning spawn one process per GPU, "
+            "which is not supported (see issue #12)."
+        ),
+    )] = 1,
 ):
     """Run cell segmentation on spatial transcriptomics data."""
 
@@ -402,6 +412,7 @@ def segment(
         max_epochs=n_epochs,
         reload_dataloaders_every_n_epochs=1,
         callbacks=[writer],
+        devices=resolve_trainer_devices(devices),
     )
 
     # Training

--- a/src/segger/debug/prediction.py
+++ b/src/segger/debug/prediction.py
@@ -9,6 +9,7 @@ def run_prediction_only(
     from segger.data import ISTDataModule
     from segger.data import ISTSegmentationWriter
     from segger.models import LitISTEncoder
+    from segger.utils import resolve_trainer_devices
 
     from lightning.pytorch.loggers import CSVLogger
     from lightning.pytorch import Trainer
@@ -22,7 +23,12 @@ def run_prediction_only(
     csvlogger = CSVLogger(path_outputs)
     writer = ISTSegmentationWriter(path_outputs, debug=True)
 
-    trainer = Trainer(logger=csvlogger, reload_dataloaders_every_n_epochs=1, callbacks=[writer],)
+    trainer = Trainer(
+        logger=csvlogger,
+        reload_dataloaders_every_n_epochs=1,
+        callbacks=[writer],
+        devices=resolve_trainer_devices(),
+    )
     datamodule = ISTDataModule.load_from_checkpoint(path_checkpoint)
     model = LitISTEncoder.load_from_checkpoint(path_checkpoint)
 

--- a/src/segger/utils.py
+++ b/src/segger/utils.py
@@ -3,6 +3,9 @@ import os
 import sys
 
 
+logger = logging.getLogger(__name__)
+
+
 class MemFilter(logging.Filter):
     def filter(self, record):
         try:
@@ -38,3 +41,53 @@ def setup_logging(level: str = "WARNING", log_file: str = None, debug: bool = Fa
         segger_log_level = os.environ.get("SEGGER_LOG_LEVEL")
         if segger_log_level:
             logging.getLogger("segger").setLevel(segger_log_level.upper())
+
+
+def visible_cuda_devices() -> int:
+    """Number of CUDA devices Lightning would see, or 0 when torch is unavailable."""
+    try:
+        import torch
+
+        return torch.cuda.device_count()
+    except Exception:
+        return 0
+
+
+def resolve_trainer_devices(devices: int = 1) -> int:
+    """Number of accelerators to hand a Lightning ``Trainer``.
+
+    Lightning's ``devices="auto"`` default claims every visible GPU and spawns one
+    process per device. Segger's CUDA work runs through cuDF/cuSpatial/CuPy on the
+    single RMM pool set up by :func:`segger.configure_memory`, which is bound to one
+    device, so the extra ranks die with `CUDA: illegal memory access` (see issue #12).
+    Pinning the trainer to one device is what `CUDA_VISIBLE_DEVICES=0` achieves by hand.
+
+    Parameters
+    ----------
+    devices : int, default 1
+        Number of accelerators to run on. Values above 1 re-enable Lightning's
+        distributed spawn, which segger's single-device CUDA pipeline does not
+        support.
+
+    Returns
+    -------
+    int
+        The number of devices to pass to ``Trainer``.
+    """
+    if devices < 1:
+        raise ValueError(f"devices must be at least 1, got {devices}.")
+
+    visible = visible_cuda_devices()
+    if devices > 1:
+        logger.warning(
+            f"Running on {devices} devices. Segger's cuDF/cuSpatial pipeline shares a "
+            f"single RMM pool and is not supported across distributed processes (see "
+            f"issue #12)."
+        )
+    elif visible > 1:
+        logger.info(
+            f"{visible} CUDA devices visible, running on 1. Segger's cuDF/cuSpatial "
+            f"pipeline is single-device (see issue #12); pass --devices to override."
+        )
+
+    return devices

--- a/tests/test_trainer_devices.py
+++ b/tests/test_trainer_devices.py
@@ -1,0 +1,121 @@
+"""Trainer device selection: segger stays on one accelerator (issue #12).
+
+Lightning's ``devices="auto"`` claims every visible GPU and spawns one process per
+device, which segger's single-device cuDF/cuSpatial pipeline cannot survive. These
+tests fake a multi-GPU host, so they need neither a GPU nor a CUDA build of torch.
+
+``segger/__init__.py`` imports cupy/rmm, so ``segger.utils`` is loaded straight from
+its file rather than through the package.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import lightning.fabric.accelerators.cuda as fabric_cuda
+import lightning.pytorch.accelerators.cuda as pytorch_cuda
+from lightning.pytorch import Trainer
+from lightning.pytorch.strategies import DDPStrategy, SingleDeviceStrategy
+
+_UTILS = Path(__file__).resolve().parents[1] / "src" / "segger" / "utils.py"
+_spec = importlib.util.spec_from_file_location("segger_utils", _UTILS)
+segger_utils = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(segger_utils)
+
+resolve_trainer_devices = segger_utils.resolve_trainer_devices
+
+
+@pytest.fixture
+def cuda_devices(monkeypatch):
+    """Make Lightning believe the host has ``n`` CUDA devices."""
+
+    def _fake(n):
+        monkeypatch.setattr(fabric_cuda, "num_cuda_devices", lambda: n)
+        monkeypatch.setattr(pytorch_cuda, "num_cuda_devices", lambda: n)
+        monkeypatch.setattr(
+            pytorch_cuda.CUDAAccelerator, "is_available", staticmethod(lambda: n > 0)
+        )
+        monkeypatch.setattr(
+            pytorch_cuda.CUDAAccelerator, "auto_device_count", staticmethod(lambda: n)
+        )
+        monkeypatch.setattr(segger_utils, "visible_cuda_devices", lambda: n)
+
+    return _fake
+
+
+def build_trainer(devices, tmp_path):
+    """The trainer segger's CLI builds, minus the segger-specific logger/callbacks."""
+    kwargs = {} if devices is None else {"devices": resolve_trainer_devices(devices)}
+    return Trainer(
+        logger=False,
+        default_root_dir=tmp_path,
+        max_epochs=1,
+        reload_dataloaders_every_n_epochs=1,
+        **kwargs,
+    )
+
+
+def test_unpinned_trainer_claims_every_gpu(cuda_devices, tmp_path):
+    """Control: Lightning's own default is what issue #12 reports."""
+    cuda_devices(2)
+    trainer = build_trainer(None, tmp_path)
+
+    assert trainer.num_devices == 2
+    assert isinstance(trainer.strategy, DDPStrategy)
+
+
+def test_two_gpus_run_on_one_device(cuda_devices, tmp_path):
+    cuda_devices(2)
+    trainer = build_trainer(1, tmp_path)
+
+    assert trainer.num_devices == 1
+    assert trainer.world_size == 1
+    assert isinstance(trainer.strategy, SingleDeviceStrategy)
+
+
+def test_single_gpu_host_is_unchanged(cuda_devices, tmp_path):
+    cuda_devices(1)
+    trainer = build_trainer(1, tmp_path)
+
+    assert trainer.num_devices == 1
+    assert isinstance(trainer.accelerator, pytorch_cuda.CUDAAccelerator)
+    assert isinstance(trainer.strategy, SingleDeviceStrategy)
+
+
+def test_cpu_host_is_unchanged(cuda_devices, tmp_path):
+    cuda_devices(0)
+    trainer = build_trainer(1, tmp_path)
+
+    assert trainer.num_devices == 1
+    assert isinstance(trainer.strategy, SingleDeviceStrategy)
+
+
+def test_multi_device_can_still_be_requested(cuda_devices, tmp_path):
+    """--devices keeps distributed training reachable for anyone who wants it."""
+    cuda_devices(2)
+    trainer = build_trainer(2, tmp_path)
+
+    assert trainer.num_devices == 2
+    assert isinstance(trainer.strategy, DDPStrategy)
+
+
+@pytest.mark.parametrize("devices", [0, -1])
+def test_non_positive_devices_rejected(devices):
+    with pytest.raises(ValueError):
+        resolve_trainer_devices(devices)
+
+
+def test_warns_when_gpus_are_left_idle(cuda_devices, caplog):
+    cuda_devices(4)
+    with caplog.at_level("INFO", logger=segger_utils.__name__):
+        assert resolve_trainer_devices() == 1
+
+    assert "4 CUDA devices visible" in caplog.text
+
+
+def test_warns_when_multiple_devices_requested(cuda_devices, caplog):
+    cuda_devices(4)
+    with caplog.at_level("WARNING", logger=segger_utils.__name__):
+        assert resolve_trainer_devices(2) == 2
+
+    assert "not supported across distributed processes" in caplog.text


### PR DESCRIPTION
This PR proposes running segger's Lightning trainers on a single device by default, so `segger segment` no longer spawns one process per GPU on a multi-GPU host and dies with `CUDA: illegal memory access` (Fixes #12). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/461. You can sign in with your GitHub ID to claim ownership of the project.

## The defect

`src/segger/cli/segment.py` builds its `Trainer` without a `devices` argument, so Lightning falls back to `devices="auto"`, takes every visible CUDA device and switches to `DDPStrategy`. That is the `Initializing distributed: GLOBAL_RANK: 0, MEMBER: 1/2` banner in #12. Each extra rank then re-runs the data module, but segger's cuDF/cuSpatial/CuPy work goes through the one RMM pool `configure_memory()` installs, so memory allocated on device 0 gets dereferenced from device 1 and the run dies with `parallel_for: failed to synchronize: cudaErrorIllegalAddress` / `CUDA_ERROR_ILLEGAL_ADDRESS`. #12 carries two by-hand workarounds: `CUDA_VISIBLE_DEVICES=0` in the original report, and later in the thread `devices=1` on the trainers, confirmed there to have the same effect. This PR makes that second one the default. `src/segger/debug/prediction.py` builds the same unpinned trainer for `segger debug predict-only`, so it is fixed alongside.

## Reproducing it at HEAD

I have no multi-GPU host, so rather than assert the crash I reproduced the step that causes it — the device selection — on `main` at ee97687, by faking the CUDA device count and building your exact trainer arguments. Nothing about Lightning's decision logic is stubbed, only the hardware count:

```python
import tempfile
import lightning.fabric.accelerators.cuda as fc, lightning.pytorch.accelerators.cuda as pc
fc.num_cuda_devices = pc.num_cuda_devices = lambda: 2
pc.CUDAAccelerator.is_available = staticmethod(lambda: True)
pc.CUDAAccelerator.auto_device_count = staticmethod(lambda: 2)

from lightning.pytorch import Trainer
from lightning.pytorch.loggers import CSVLogger
trainer = Trainer(logger=CSVLogger(tempfile.mkdtemp()), max_epochs=20, reload_dataloaders_every_n_epochs=1, callbacks=[])
print(type(trainer.strategy).__name__, trainer.num_devices, trainer.world_size)
```

```
before:  DDPStrategy            num_devices=2  world_size=2
after:   SingleDeviceStrategy   num_devices=1  world_size=1
```

## The change

`resolve_trainer_devices()` in `src/segger/utils.py` returns the device count to hand Lightning; it defaults to 1 and logs why when more GPUs are visible. Both trainers pass it. `segger segment` gains `--devices` so multi-GPU is still reachable for anyone who wants to experiment with it, and it warns when asked for more than one. Nothing else moves: on a single-GPU host and on a CPU-only host the resolved strategy and device count are identical to today.

## Verifying it

`tests/test_trainer_devices.py` covers this with the same faked host, so it needs neither a GPU nor a CUDA build of torch — `pytest tests/` runs it anywhere in about two seconds. Nine tests: the two-GPU host lands on `SingleDeviceStrategy`, single-GPU and CPU hosts are unchanged, `--devices 2` still reaches `DDPStrategy`, non-positive values raise, and both log paths fire. Reverting only the line that pins the count turns five of them red while the four controls — including the one that documents Lightning's own unpinned behaviour — stay green.

To be explicit about scope: the repository ships no test suite and no CI workflow, so there was no existing suite to regress. What I ran before and after the change was `python -m compileall src/segger` (clean both times) and the tests above. What I could not run on this machine is an actual segmentation, or the CUDA fault itself, because cupy/cuSpatial/rmm are CUDA-only and `import segger` therefore fails here — which is also why the new tests load `src/segger/utils.py` by path instead of importing the package.

Two things worth your judgement rather than mine. First, this changes a default: today a two-GPU host uses both and crashes, after this it uses one and runs, and `--devices` is the way back. Second, #51 also touches `src/segger/cli/segment.py`, though not the trainer construction, so I expect no conflict there.

## How this was managed

Your issues and pull requests were imported to a board — 69 stories — and this work was tracked on it as [CUDA illegal memory access when running Segger on multi-GPU machine](https://eastagiletracker.com/projects/461/stories/406562), the story matching #12. The board is live at https://eastagiletracker.com/projects/461.

![board](https://raw.githubusercontent.com/eastagiletracker/segger/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
