### PR TITLE
[main] Enforce single GPU per trainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ __marimo__/
 *memray*
 rmm_log.txt
 /nvidia/
+nvidia/

--- a/src/segger/cli/segment.py
+++ b/src/segger/cli/segment.py
@@ -415,6 +415,7 @@ def segment(
         max_epochs=n_epochs,
         reload_dataloaders_every_n_epochs=1,
         callbacks=callbacks,
+        devices=1,
     )
 
     # Training

--- a/src/segger/debug/prediction.py
+++ b/src/segger/debug/prediction.py
@@ -88,7 +88,7 @@ def run_prediction_only(
     csvlogger = CSVLogger(path_outputs)
     writer = ISTSegmentationWriter(path_outputs, debug=True)
 
-    trainer = Trainer(logger=csvlogger, reload_dataloaders_every_n_epochs=1, callbacks=[writer],)
+    trainer = Trainer(logger=csvlogger, reload_dataloaders_every_n_epochs=1, callbacks=[writer], devices=1,)
     datamodule = ISTDataModule.load_from_checkpoint(path_checkpoint)
     model = LitISTEncoder.load_from_checkpoint(path_checkpoint)
 


### PR DESCRIPTION
Closes #12, where segger tries to use all assigned GPUs. Thanks to @eastagiletracker for finding this fix (closing #82 as out of scope).

Tested this on a SLURM cluster before/after the fix and confirmed this fixes the issue.