### PR TITLE
[main] Fix quadtree leaf boundaries to match cuSpatial's clamped scale

### DIFF
--- a/src/segger/geometry/quadtree.py
+++ b/src/segger/geometry/quadtree.py
@@ -40,7 +40,10 @@ def get_quadtree_kwargs(
     max_depth = 1
     while extent // (1 << max_depth) > 0:
         max_depth += 1
-    scale = extent // (1 << max_depth - 1)
+    max_depth = min(max_depth, 15)
+
+    # Match cuSpatial's own min-scale formula so it never silently clamps this up.
+    scale = extent / ((1 << max_depth) + 2)
 
     # Return as dictionary
     return dict(
@@ -49,7 +52,7 @@ def get_quadtree_kwargs(
         y_min=y_min,
         y_max=y_max,
         scale=scale,
-        max_depth=min(max_depth, 15),
+        max_depth=max_depth,
     )
 
 
@@ -100,6 +103,8 @@ def get_quadrant_bounds(
     x_max: float,
     y_min: float,
     y_max: float,
+    scale: float,
+    max_depth: int,
 ):
     """
     Add spatial bounds to each leaf in a cuSpatial quadtree.
@@ -115,6 +120,12 @@ def get_quadrant_bounds(
         Full extent of the quadtree in x-direction.
     y_min, y_max : float
         Full extent of the quadtree in y-direction.
+    scale : float
+        The `scale` actually used by cuSpatial to build `quadtree` (i.e. the
+        leaf cell width). Must match, or leaf boundaries will be computed for
+        a different cell size than the tree cuSpatial built.
+    max_depth : int
+        The `max_depth` actually used by cuSpatial to build `quadtree`.
 
     Returns
     -------
@@ -122,13 +133,10 @@ def get_quadrant_bounds(
         Input DataFrame with added bounding box columns: 'x_min', 'x_max',
         'y_min', and 'y_max'.
     """
-    width =  x_max - x_min
-    height = y_max - y_min
     levels = quadtree['level'].astype(float) + 1
     coords = cp.array(keys_to_coordinates(quadtree['key'].to_numpy()))
-    quadrant_max = np.ceil(np.log2(max(width, height)))
-    quadrant_dim = 2 ** (quadrant_max - levels)
-    
+    quadrant_dim = scale * 2 ** (max_depth - levels)
+
     quadtree['x_min'] = x_min + coords[0] * quadrant_dim
     quadtree['x_max'] = quadtree['x_min'] + quadrant_dim
     quadtree['y_min'] = y_min + coords[1] * quadrant_dim
@@ -215,6 +223,8 @@ def get_quadtree_index(
             x_max=x_max,
             y_min=y_min,
             y_max=y_max,
+            scale=scale,
+            max_depth=max_depth,
         )
 
     return indices, quadtree, kwargs


### PR DESCRIPTION
`get_quadrant_bounds()` built leaf polygons assuming `scale=1`, but cuSpatial clamps scale up once `max_depth` hits its cap of 15. Above an extent of ~32,770 µm the tile boundaries stop matching the tree cuSpatial built, dropping ~50% of points from every tile and crashing `bincount` on an all `-1` label tensor. Xenium slides sit below that threshold; CosMx slides exceed it, so this fixes the larger areas.

Fix: compute `scale` from cuSpatial's own min-scale formula and pass the real `(scale, max_depth)` into `get_quadrant_bounds`.

This fix worked for me on the CosMx pancreas dataset that crashed: 0/64,960,205 `tx` and 0/47,488 `bd` points unmatched, no clamp warning.
